### PR TITLE
feat: add week 1 content and widgets

### DIFF
--- a/data/week1.json
+++ b/data/week1.json
@@ -1,196 +1,307 @@
 {
-  "id":1,
-  "title":"Week 1 — Kickoff & Introductions",
-  "goals":[
-    "Confident self-introduction and role description",
-    "Deliver 1-minute stand-up updates",
-    "Master 12–18 industry terms"
+  "id": 1,
+  "title": "Week 1 — Kickoff & Introductions",
+  "goals": [
+    "Confident self-introduction and role description in English",
+    "Deliver concise 1-minute stand-up updates",
+    "Master 12–18 core industry terms and use them in context"
   ],
-  "days":[
+  "days": [
     {
-      "day":1,
-      "title":"Kickoff & Group Orientation",
-      "focus":"Welcome, objectives, introductions",
-      "vocabulary":["project","team","role","ODM","supplier"],
-      "activities":[
-        {"type":"speak","title":"Round-robin intro","duration":10,"instructions":"Name, role, current project."},
-        {"type":"write","title":"3-sentence self-intro","duration":10,"instructions":"Write and read aloud."},
-        {"type":"checklist","title":"Set personal goals","items":["Fluency","Accuracy","Confidence"]}
+      "day": 1,
+      "title": "Kickoff & Group Orientation",
+      "focus": "Welcome, objectives, introductions; set individual learning goals.",
+      "vocabulary": ["project","team","role","ODM","supplier","milestone","deliverable","status","risk","update","owner","deadline"],
+      "activities": [
+        {"type":"speak","title":"Round-robin intro","duration":10,"instructions":"Say your name, role, and current project in 2–3 sentences."},
+        {"type":"write","title":"3-sentence self-intro","duration":10,"instructions":"Write a short self-introduction and read it aloud."},
+        {"type":"checklist","title":"Set personal goals","items":["Improve fluency","Use industry terms naturally","Give clear 1-min updates"]},
+        {"type":"reflect","title":"Learning journal","instructions":"What is hardest about speaking in meetings? Write 3–4 sentences."}
       ],
-      "templates":[
+      "templates": [
         "I’m responsible for …",
-        "This week my focus is …"
+        "This week my focus is …",
+        "My current project is … and my role is …"
       ],
-      "quiz":{"questions":[
-        {"q":"ODM stands for…","choices":["Original Design Manufacturer","Open Device Manufacturing","On-Demand Module"],"answer":0},
-        {"q":"A supplier is…","choices":["An internal tester","A vendor providing parts","A customer"],"answer":1}
-      ]},
-      "flashcards":[
-        {"term":"milestone","definition":"A planned event marking progress"},
-        {"term":"deliverable","definition":"A tangible output due at a date"},
-        {"term":"tooling","definition":"Equipment used to manufacture parts"},
-        {"term":"EVT","definition":"Engineering Validation Test phase"}
+      "usageExamples": [
+        "Our milestone this week is the EVT readiness review.",
+        "I will share a status update on tooling progress tomorrow."
       ],
-      "homework":[
-        "Record a 45-sec intro and self-critique (clarity, speed, pauses).",
-        "Collect 5 role-specific verbs you use daily."
+      "quiz": {
+        "questions": [
+          {"q":"What does ODM stand for?","choices":["Original Design Manufacturer","On-Demand Manufacturing","Open Device Model"],"answer":0},
+          {"q":"A deliverable is…","choices":["A meeting room","A tangible output due at a date","A software license"],"answer":1}
+        ]
+      },
+      "flashcards": [
+        {"term":"milestone","definition":"A planned event marking progress."},
+        {"term":"deliverable","definition":"A tangible output due at a specific date."},
+        {"term":"owner","definition":"Person accountable for a task."},
+        {"term":"risk","definition":"An uncertain event that may impact goals."}
       ],
-      "rubric":[
+      "homework": [
+        "Record a 45-second self-intro; review clarity and pace.",
+        "Collect 5 verbs you use daily (coordinate, follow up, escalate, align, validate)."
+      ],
+      "rubric": [
         {"dimension":"Clarity","levels":["basic","good","excellent"]},
-        {"dimension":"Vocabulary usage","levels":["limited","adequate","precise"]}
+        {"dimension":"Vocabulary usage","levels":["limited","adequate","precise"]},
+        {"dimension":"Confidence","levels":["shy","steady","assertive"]}
       ],
-      "timebox":{"total":30,"segments":[10,10,10]},
-      "materials":["notebook","timer"]
+      "timebox": {"total":35,"segments":[10,10,10,5]},
+      "materials": ["notebook","timer"]
     },
     {
-      "day":2,
-      "title":"Stand-up Structure",
-      "focus":"Organizing brief daily updates",
-      "vocabulary":["stand-up","blocker","ETA"],
-      "activities":[
-        {"type":"speak","title":"30-sec update","duration":5,"instructions":"Yesterday, today, blockers."},
-        {"type":"checklist","title":"Update formula","items":["Yesterday","Today","Blockers"]}
+      "day": 2,
+      "title": "Describing Roles & Responsibilities",
+      "focus": "Explain your responsibilities and coordination lines.",
+      "vocabulary": ["project manager","procurement","engineering","manufacturing","quality","risk control","stakeholder","alignment","handoff","dependency","scope","escalation"],
+      "activities": [
+        {"type":"read","title":"Role map","instructions":"Read a sample RACI and identify your responsibilities."},
+        {"type":"write","title":"Role paragraph","duration":10,"instructions":"Write 4–5 sentences about your responsibilities and key partners."},
+        {"type":"speak","title":"Peer review","duration":8,"instructions":"Read your paragraph to a partner; partner suggests 1 stronger verb."},
+        {"type":"checklist","title":"Role verbs","items":["coordinate","prioritize","escalate","validate","track"]}
       ],
-      "templates":["Yesterday I…","Today I will…"],
-      "quiz":{"questions":[
-        {"q":"A blocker is…","choices":["A completed task","Something preventing progress","A helpful teammate"],"answer":1},
-        {"q":"ETA means…","choices":["Estimated Time of Arrival","Engineering Test Approval","End Task Assessment"],"answer":0}
-      ]},
-      "flashcards":[
-        {"term":"DVT","definition":"Design Validation Test phase"},
-        {"term":"lead time","definition":"Time between order and delivery"},
-        {"term":"FPY","definition":"First Pass Yield"},
-        {"term":"PPM","definition":"Parts Per Million defect rate"}
+      "templates": [
+        "I am responsible for … and I coordinate with …",
+        "My main stakeholders are … because …"
       ],
-      "homework":["Write a sample stand-up update."],
-      "rubric":[{"dimension":"Conciseness","levels":["rambling","clear","crisp"]}],
-      "timebox":{"total":20,"segments":[5,5,10]},
-      "materials":["timer"]
+      "usageExamples": [
+        "I coordinate with engineering on validation and with procurement on lead times.",
+        "If scope changes, I escalate for approval."
+      ],
+      "quiz": {
+        "questions": [
+          {"q":"Stakeholder means…","choices":["Only internal team members","Anyone affected by project outcomes","Only suppliers"],"answer":1},
+          {"q":"Escalation is used to…","choices":["Delay decisions","Raise an issue for higher-level decision","Avoid responsibility"],"answer":1}
+        ]
+      },
+      "flashcards": [
+        {"term":"stakeholder","definition":"Anyone affected by or influencing the project."},
+        {"term":"alignment","definition":"Shared understanding and agreement on goals."},
+        {"term":"handoff","definition":"Transfer of work or responsibility."},
+        {"term":"dependency","definition":"A task that relies on another task’s completion."}
+      ],
+      "homework": [
+        "Rewrite your role paragraph using 2 new verbs and 2 role nouns.",
+        "List top 3 stakeholders and their expectations."
+      ],
+      "rubric": [
+        {"dimension":"Specificity","levels":["vague","clear","concrete"]},
+        {"dimension":"Structure","levels":["loose","ordered","tight"]}
+      ],
+      "timebox": {"total":35,"segments":[8,10,8,9]},
+      "materials": ["sample RACI","timer"]
     },
     {
-      "day":3,
-      "title":"Project Roles & Responsibilities",
-      "focus":"Explaining who does what",
-      "vocabulary":["stakeholder","handoff","escalation"],
-      "activities":[
-        {"type":"roleplay","title":"Escalation scenario","duration":10,"instructions":"Practice raising an issue."},
-        {"type":"checklist","title":"Role clarity","items":["Who decides","Who informs","Who acts"]}
+      "day": 3,
+      "title": "Describing Daily Tasks",
+      "focus": "Explain routine activities and cadence.",
+      "vocabulary": ["stand-up","follow-up","status report","supplier call","ETA","blocker","backlog","priority","update","risk review","meeting notes","action item"],
+      "activities": [
+        {"type":"speak","title":"Morning vs afternoon","duration":8,"instructions":"Describe your morning and afternoon routines in 3–4 sentences."},
+        {"type":"write","title":"Daily plan note","duration":10,"instructions":"Write a 5-line plan including 1 risk and 1 dependency."},
+        {"type":"timer","title":"Focus timer","instructions":"Set 10-minute timer; draft a status note without pausing."}
       ],
-      "templates":["I am accountable for…"],
-      "quiz":{"questions":[
-        {"q":"Escalation means…","choices":["Lowering priority","Raising an issue","Hiring staff"],"answer":1},
-        {"q":"A stakeholder is…","choices":["Any interested party","Only the customer","The factory"],"answer":0}
-      ]},
-      "flashcards":[
-        {"term":"second source","definition":"Alternative supplier for risk"},
-        {"term":"acceptance criteria","definition":"Standards to accept work"},
-        {"term":"contingency plan","definition":"Fallback strategy"},
-        {"term":"risk register","definition":"List of project risks"}
+      "templates": [
+        "In the morning, I usually …",
+        "My main blocker today is … so I will …",
+        "ETA for the supplier response is …"
       ],
-      "homework":["Map roles on your current project."],
-      "rubric":[{"dimension":"Role clarity","levels":["vague","defined","precise"]}],
-      "timebox":{"total":25,"segments":[10,15]},
-      "materials":["notebook"]
+      "usageExamples": [
+        "The backlog review is in the afternoon; I’ll prioritize two action items.",
+        "We have a blocker on camera SFR validation."
+      ],
+      "quiz": {
+        "questions": [
+          {"q":"Blocker means…","choices":["A small delay","A task that stops progress until resolved","A low priority item"],"answer":1},
+          {"q":"ETA stands for…","choices":["Estimated Time of Arrival","Engineering Test Agreement","Escalation To Admin"],"answer":0}
+        ]
+      },
+      "flashcards": [
+        {"term":"stand-up","definition":"Short daily status meeting."},
+        {"term":"action item","definition":"A specific task with an owner and deadline."},
+        {"term":"backlog","definition":"List of pending tasks or issues."},
+        {"term":"ETA","definition":"Estimated time of arrival/availability."}
+      ],
+      "homework": [
+        "Write a 3-sentence status update using 2 vocabulary words.",
+        "Prepare 2 clarifying questions for your supplier."
+      ],
+      "rubric": [
+        {"dimension":"Brevity","levels":["rambling","concise","crisp"]},
+        {"dimension":"Use of terms","levels":["few","some","consistent"]}
+      ],
+      "timebox": {"total":30,"segments":[8,10,10,2]},
+      "materials": ["timer"]
     },
     {
-      "day":4,
-      "title":"Vocabulary Drill",
-      "focus":"Reinforcing industry terms",
-      "vocabulary":["kickoff","backlog"],
-      "activities":[
-        {"type":"speak","title":"Use new terms","duration":10,"instructions":"Describe your backlog."},
-        {"type":"timer","title":"Flash review","duration":5,"instructions":"Timed recall using cards."}
+      "day": 4,
+      "title": "Stand-Up Status Updates",
+      "focus": "Deliver a concise 1-minute update.",
+      "vocabulary": ["on track","delay","pending","milestone","next step","owner","commit date","scope","impact","recover","mitigation","risk register"],
+      "activities": [
+        {"type":"speak","title":"1-minute update","duration":10,"instructions":"State progress, blockers, next steps, and a date."},
+        {"type":"write","title":"Update script","duration":10,"instructions":"Write 60–80 words. Include 1 risk and 1 mitigation."},
+        {"type":"roleplay","title":"PM ↔ stakeholder Q&A","instructions":"Partner asks 2 follow-ups; answer succinctly."}
       ],
-      "templates":["Our kickoff is set for…"],
-      "quiz":{"questions":[
-        {"q":"Backlog refers to…","choices":["Completed tasks","Outstanding tasks","Budget"],"answer":1},
-        {"q":"Kickoff meeting occurs…","choices":["At project end","At project start","After DVT"],"answer":1}
-      ]},
-      "flashcards":[
-        {"term":"scope","definition":"Work to be done"},
-        {"term":"change request","definition":"Formal ask to modify scope"},
-        {"term":"Gantt chart","definition":"Timeline diagram"},
-        {"term":"critical path","definition":"Sequence determining project duration"}
+      "templates": [
+        "This week my focus is …",
+        "We have a delay in …; our mitigation is …",
+        "The next milestone is … with a commit date of …"
       ],
-      "homework":["Create sentences with 5 new terms."],
-      "rubric":[{"dimension":"Vocabulary recall","levels":["low","medium","high"]}],
-      "timebox":{"total":15,"segments":[10,5]},
-      "materials":["flashcards"]
+      "usageExamples": [
+        "We’re on track for EVT; risk is supplier holiday; mitigation is buffer stock.",
+        "Scope change may impact timeline; re-baselining proposed."
+      ],
+      "quiz": {
+        "questions": [
+          {"q":"Mitigation is…","choices":["Root cause","Action to reduce risk impact/probability","Approval document"],"answer":1},
+          {"q":"Commit date means…","choices":["Tentative idea","Public holiday","Agreed delivery/finish date"],"answer":2}
+        ]
+      },
+      "flashcards": [
+        {"term":"mitigation","definition":"Action to reduce risk likelihood/impact."},
+        {"term":"commit date","definition":"Agreed date to deliver/finish a task."},
+        {"term":"risk register","definition":"List of risks with owners and plans."},
+        {"term":"recover","definition":"Actions to bring schedule back on track."}
+      ],
+      "homework": [
+        "Record your 1-minute update; self-assess clarity and timing.",
+        "Note 1 improvement for tomorrow."
+      ],
+      "rubric": [
+        {"dimension":"Structure","levels":["unclear","logical","sharp"]},
+        {"dimension":"Timing","levels":[">75s","60–70s","~60s"]}
+      ],
+      "timebox": {"total":35,"segments":[10,10,10,5]},
+      "materials": ["timer","recorder"]
     },
     {
-      "day":5,
-      "title":"Meeting Etiquette",
-      "focus":"Polite interjections and clarifications",
-      "vocabulary":["clarify","agenda","parking lot"],
-      "activities":[
-        {"type":"speak","title":"Polite interrupt","duration":5,"instructions":"Excuse me, may I clarify…"},
-        {"type":"checklist","title":"Agenda review","items":["Purpose","Topics","Timing"]}
+      "day": 5,
+      "title": "Industry Vocabulary — ODM & Manufacturing Basics",
+      "focus": "Master essential manufacturing terms and usage.",
+      "vocabulary": ["tooling","EVT","DVT","prototype","production line","lead time","capacity","defect","yield","PPM","FPY","acceptance criteria"],
+      "activities": [
+        {"type":"read","title":"Glossary scan","instructions":"Read definitions for 12 terms; star 3 to practice aloud."},
+        {"type":"speak","title":"Usage drill","duration":10,"instructions":"Make a sentence for 5 terms relevant to your project."},
+        {"type":"checklist","title":"Vocab goals","items":["Use 5 terms in context","Teach 1 term to a peer","Write 3 example sentences"]}
       ],
-      "templates":["Could you clarify…?"],
-      "quiz":{"questions":[
-        {"q":"Agenda helps…","choices":["Track attendance","Structure the meeting","Send emails"],"answer":1},
-        {"q":"Parking lot holds…","choices":["Cars","Deferred topics","Snacks"],"answer":1}
-      ]},
-      "flashcards":[
-        {"term":"action item","definition":"Task assigned to someone"},
-        {"term":"minutes","definition":"Written record of meeting"},
-        {"term":"follow-up","definition":"Subsequent action"},
-        {"term":"timebox","definition":"Fixed duration"}
+      "templates": [
+        "The tooling is ready for …",
+        "We start EVT next week after …",
+        "Acceptance criteria for DVT include …"
       ],
-      "homework":["Prepare agenda for next team meeting."],
-      "rubric":[{"dimension":"Politeness","levels":["rough","courteous","graceful"]}],
-      "timebox":{"total":20,"segments":[10,10]},
-      "materials":["timer"]
+      "usageExamples": [
+        "Lead time for the camera module is 4 weeks.",
+        "FPY improved from 88% to 93% after the process tweak."
+      ],
+      "quiz": {
+        "questions": [
+          {"q":"FPY stands for…","choices":["First Pass Yield","Final Product Year","Factory Process Yard"],"answer":0},
+          {"q":"Acceptance criteria are…","choices":["Marketing slogans","Conditions that must be met to approve a build/phase","Supplier discounts"],"answer":1}
+        ]
+      },
+      "flashcards": [
+        {"term":"FPY","definition":"Units passing without rework / total."},
+        {"term":"PPM","definition":"Defects per million opportunities/units."},
+        {"term":"acceptance criteria","definition":"Conditions to approve a phase/test."},
+        {"term":"lead time","definition":"Time from order to availability."}
+      ],
+      "homework": [
+        "Write 5 sentences using today’s terms; highlight verbs + nouns.",
+        "Prepare 3 acceptance criteria for your next build."
+      ],
+      "rubric": [
+        {"dimension":"Accuracy","levels":["some errors","mostly correct","precise"]},
+        {"dimension":"Context use","levels":["forced","adequate","natural"]}
+      ],
+      "timebox": {"total":30,"segments":[8,10,8,4]},
+      "materials": ["glossary sheet"]
     },
     {
-      "day":6,
-      "title":"Status Report Language",
-      "focus":"Describing progress and risks",
-      "vocabulary":["on track","slipped","mitigation"],
-      "activities":[
-        {"type":"write","title":"Status email","duration":10,"instructions":"Include risk and mitigation."},
-        {"type":"checklist","title":"Risk sentence","items":["Issue","Impact","Mitigation"]}
+      "day": 6,
+      "title": "Supplier Call Simulation",
+      "focus": "Ask for updates, confirm dates, and address constraints politely but firmly.",
+      "vocabulary": ["shipment","lead time","material","quality","delivery","commitment","expedite","partial shipment","priority","capacity","promise date","constraint"],
+      "activities": [
+        {"type":"roleplay","title":"PM ↔ supplier call","instructions":"Request shipment date, discuss constraints, agree next steps."},
+        {"type":"write","title":"Call summary email","duration":10,"instructions":"Write 120–150 words including promise date and action items."},
+        {"type":"timer","title":"Focused drafting","instructions":"Set a 7-minute timer; write without stopping."}
       ],
-      "templates":["The schedule has slipped due to…"],
-      "quiz":{"questions":[
-        {"q":"Mitigation is…","choices":["Ignoring risk","Plan to reduce impact","Escalation"],"answer":1},
-        {"q":"On track means…","choices":["Behind schedule","Proceeding as planned","Cancelled"],"answer":1}
-      ]},
-      "flashcards":[
-        {"term":"dashboard","definition":"Visual status summary"},
-        {"term":"KPI","definition":"Key Performance Indicator"},
-        {"term":"variance","definition":"Difference from plan"},
-        {"term":"dependency","definition":"Task reliant on another"}
+      "templates": [
+        "Can you confirm the shipment date for …?",
+        "We appreciate your effort; however, the promise date must be …",
+        "Could we expedite a partial shipment of …?"
       ],
-      "homework":["Send a status email to a teammate."],
-      "rubric":[{"dimension":"Risk articulation","levels":["unclear","clear","insightful"]}],
-      "timebox":{"total":25,"segments":[15,10]},
-      "materials":["notebook"]
+      "usageExamples": [
+        "Due to capacity constraints, the supplier proposed a partial shipment.",
+        "Quality checks will complete by Wednesday; delivery is Friday."
+      ],
+      "quiz": {
+        "questions": [
+          {"q":"‘Expedite’ means…","choices":["Cancel the order","Speed up processing/shipping","Delay for review"],"answer":1},
+          {"q":"A partial shipment is…","choices":["An incomplete product","A split delivery of available units","A sample unit"],"answer":1}
+        ]
+      },
+      "flashcards": [
+        {"term":"promise date","definition":"Supplier’s committed delivery date."},
+        {"term":"expedite","definition":"Speed up processing or shipping."},
+        {"term":"partial shipment","definition":"Deliver available portion earlier."},
+        {"term":"capacity","definition":"Maximum output the supplier can deliver."}
+      ],
+      "homework": [
+        "Send a draft escalation email requesting a firmer promise date.",
+        "List 2 trade-offs for expedite vs full batch."
+      ],
+      "rubric": [
+        {"dimension":"Tone","levels":["too soft","polite","polite+firm"]},
+        {"dimension":"Specificity","levels":["vague","clear","actionable"]}
+      ],
+      "timebox": {"total":35,"segments":[12,10,7,6]},
+      "materials": ["timer","email template"]
     },
     {
-      "day":7,
-      "title":"Week Review & Reflection",
-      "focus":"Summarizing learning and planning next steps",
-      "vocabulary":["retrospective","lesson learned"],
-      "activities":[
-        {"type":"reflect","title":"Weekly journal","duration":15,"instructions":"What worked, what to change"},
-        {"type":"speak","title":"Share lesson","duration":5,"instructions":"One takeaway"}
+      "day": 7,
+      "title": "Review & Mini Presentation",
+      "focus": "Consolidate Week 1; present self-intro + status update.",
+      "vocabulary": ["integration","summary","highlight","lowlight","next steps","confidence","timing","feedback","improvement","reflection","practice","cadence"],
+      "activities": [
+        {"type":"speak","title":"2-min presentation","duration":12,"instructions":"Self-intro + this week’s status + next steps."},
+        {"type":"reflect","title":"Feedback notes","instructions":"Write 3 strengths and 2 improvements."},
+        {"type":"checklist","title":"Completion check","items":["All quizzes done","Flashcards reviewed","Homework submitted"]}
       ],
-      "templates":["One lesson I learned is…"],
-      "quiz":{"questions":[
-        {"q":"Retrospective is…","choices":["Future plan","Past review","Budget report"],"answer":1},
-        {"q":"Lesson learned is…","choices":["Issue ignored","Insight gained","Meeting type"],"answer":1}
-      ]},
-      "flashcards":[
-        {"term":"iteration","definition":"Single development cycle"},
-        {"term":"scope creep","definition":"Uncontrolled expansion of scope"},
-        {"term":"baseline","definition":"Approved plan"},
-        {"term":"closure","definition":"Formal completion"}
+      "templates": [
+        "The highlight this week was …; a lowlight was …",
+        "Next week I will focus on … to improve …"
       ],
-      "homework":["Plan one improvement for next week."],
-      "rubric":[{"dimension":"Reflection depth","levels":["shallow","thoughtful","insightful"]}],
-      "timebox":{"total":20,"segments":[15,5]},
-      "materials":["journal"]
+      "usageExamples": [
+        "My confidence improved; timing is closer to 60 seconds.",
+        "Next week I’ll practice acceptance-criteria phrasing."
+      ],
+      "quiz": {
+        "questions": [
+          {"q":"A ‘highlight’ is…","choices":["A risk","A key positive point","A defect"],"answer":1},
+          {"q":"Reflection helps you…","choices":["Forget tasks","Identify improvements","Avoid feedback"],"answer":1}
+        ]
+      },
+      "flashcards": [
+        {"term":"highlight","definition":"A noteworthy positive outcome."},
+        {"term":"lowlight","definition":"A noteworthy negative or challenge."},
+        {"term":"reflection","definition":"Thinking critically about performance."},
+        {"term":"cadence","definition":"The regular rhythm/sequence of activities."}
+      ],
+      "homework": [
+        "Write a 100-word reflection: one strength, one weakness, one next action.",
+        "Schedule two 10-minute speaking practices for Week 2."
+      ],
+      "rubric": [
+        {"dimension":"Delivery","levels":["hesitant","steady","confident"]},
+        {"dimension":"Content","levels":["thin","sufficient","compelling"]}
+      ],
+      "timebox": {"total":30,"segments":[12,8,10]},
+      "materials": ["timer","notes"]
     }
   ]
 }
+

--- a/scripts/ui/components.js
+++ b/scripts/ui/components.js
@@ -1,35 +1,198 @@
-// UI component helpers
-export function Card(title, body){
-  const div=document.createElement('div');
-  div.className='card';
-  if(title){const h=document.createElement('h3');h.textContent=title;div.appendChild(h);}
-  if(body){div.appendChild(body);} return div;
+// Core UI component helpers
+// Components are kept minimal and data-driven. Persistence is handled via
+// storage.js using week/day scoped keys.
+
+import {getDay, setDay} from './storage.js';
+import {createTimer} from './timers.js';
+import {renderQuiz} from './quiz.js';
+import {renderFlashcards} from './flashcards.js';
+
+// Utility: toast message
+export function Toast(msg) {
+  const t = document.createElement('div');
+  t.className = 'toast';
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(() => t.remove(), 2000);
 }
 
-export function Accordion({id,title}, content){
-  const section=document.createElement('section');section.className='accordion';
-  const btn=document.createElement('button');btn.id=id;btn.setAttribute('aria-expanded','false');btn.textContent=title;
-  const icon=document.createElement('span');icon.textContent='+';btn.appendChild(icon);
-  const div=document.createElement('div');div.className='accordion-content';
-  btn.addEventListener('click',()=>{const open=div.classList.toggle('open');btn.setAttribute('aria-expanded',open);});
-  if(content)div.appendChild(content);section.append(btn,div);return section;
+// Copy button with toast feedback
+export function CopyButton(text) {
+  const btn = document.createElement('button');
+  btn.className = 'copy';
+  btn.textContent = 'Copy';
+  btn.addEventListener('click', () => {
+    navigator.clipboard.writeText(text).then(() => Toast('Copied'));
+  });
+  return btn;
 }
 
-export function ProgressRing(percent){
-  const svg=`<svg class="progress-ring" viewBox="0 0 36 36"><path stroke="var(--shadow)" stroke-width="2" fill="none" d="M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32"/><path stroke="var(--tint)" stroke-width="2" fill="none" stroke-dasharray="${percent} ${100-percent}" d="M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32"/></svg>`;
-  const div=document.createElement('div');div.innerHTML=svg;return div.firstChild;
+// Accessible accordion section
+export function Accordion({ id, title }, content) {
+  const section = document.createElement('section');
+  section.className = 'accordion';
+
+  const header = document.createElement('h2');
+  const btn = document.createElement('button');
+  btn.id = id;
+  btn.setAttribute('aria-expanded', 'false');
+  btn.setAttribute('aria-controls', `${id}-panel`);
+  btn.innerHTML = `<span>${title}</span>`;
+  header.appendChild(btn);
+
+  const panel = document.createElement('div');
+  panel.id = `${id}-panel`;
+  panel.hidden = true;
+  panel.className = 'accordion-content';
+  panel.setAttribute('role', 'region');
+  panel.setAttribute('aria-labelledby', id);
+
+  btn.addEventListener('click', () => {
+    const open = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', String(!open));
+    panel.hidden = open;
+    if (!open) panel.focus();
+  });
+
+  if (content) panel.appendChild(content);
+  section.append(header, panel);
+  return section;
 }
 
-export function Toast(msg){const t=document.createElement('div');t.className='toast';t.textContent=msg;document.body.appendChild(t);setTimeout(()=>t.remove(),2000);}
+// SVG progress ring
+export function ProgressRing(percent) {
+  const circ = 2 * Math.PI * 16;
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 36 36');
+  svg.classList.add('progress-ring');
 
-export function Checklist(items){const ul=document.createElement('ul');ul.className='checklist';items.forEach(i=>{const li=document.createElement('li');const cb=document.createElement('input');cb.type='checkbox';li.append(cb,document.createTextNode(i));ul.appendChild(li);});return ul;}
+  const bg = document.createElementNS(svg.namespaceURI, 'path');
+  bg.setAttribute('d', 'M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32');
+  bg.setAttribute('stroke', 'var(--shadow)');
+  bg.setAttribute('stroke-width', '2');
+  bg.setAttribute('fill', 'none');
 
-export function Timer({seconds}){let time=seconds;const container=document.createElement('div');const disp=document.createElement('div');disp.className='timer-display';const btn=document.createElement('button');btn.textContent='Start';container.append(disp,btn);function render(){disp.textContent=`${String(Math.floor(time/60)).padStart(2,'0')}:${String(time%60).padStart(2,'0')}`;}render();let interval=null;btn.addEventListener('click',()=>{if(interval){clearInterval(interval);interval=null;btn.textContent='Start';}else{btn.textContent='Pause';interval=setInterval(()=>{if(time>0){time--;render();if(time===0){clearInterval(interval);Toast('Done');}}},1000);}});return container;}
+  const fg = document.createElementNS(svg.namespaceURI, 'path');
+  fg.setAttribute('d', 'M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32');
+  fg.setAttribute('stroke', 'var(--tint)');
+  fg.setAttribute('stroke-width', '2');
+  fg.setAttribute('fill', 'none');
+  fg.setAttribute('stroke-dasharray', `${(percent / 100) * circ} ${circ}`);
 
-export function Quiz(questions){let score=0;const div=document.createElement('div');questions.forEach((q,idx)=>{const wrap=document.createElement('div');wrap.className='quiz-question';const p=document.createElement('p');p.textContent=q.q;wrap.appendChild(p);q.choices.forEach((c,i)=>{const btn=document.createElement('button');btn.textContent=c;btn.addEventListener('click',()=>{if(i===q.answer){btn.classList.add('correct');score++;}else btn.classList.add('wrong');btn.disabled=true;});wrap.appendChild(btn);});div.appendChild(wrap);});return div;}
+  svg.append(bg, fg);
+  return svg;
+}
 
-export function Flashcards(cards){let index=0;const div=document.createElement('div');const card=document.createElement('div');card.className='flashcard';div.appendChild(card);function render(){card.textContent=index%2===0?cards[Math.floor(index/2)].term:cards[Math.floor(index/2)].definition;}render();card.addEventListener('click',()=>{index=(index+1)%(cards.length*2);render();});return div;}
+// Checklist component; items is array of strings. Persist state per item.
+export function Checklist({ items, weekId, day, key }) {
+  const data = getDay(weekId, day);
+  const state = data[key] || {};
+  const ul = document.createElement('ul');
+  ul.className = 'checklist';
 
-export function Rubric(dimensions){const div=document.createElement('div');dimensions.forEach(d=>{const row=document.createElement('div');row.className='rubric-row';const label=document.createElement('label');label.textContent=d.dimension;const select=document.createElement('select');d.levels.forEach(l=>{const opt=document.createElement('option');opt.value=l;opt.textContent=l;select.appendChild(opt);});row.append(label,select);div.appendChild(row);});return div;}
+  items.forEach((text) => {
+    const li = document.createElement('li');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = Boolean(state[text]);
+    cb.id = `${key}-${text}`;
+    cb.addEventListener('change', () => {
+      state[text] = cb.checked;
+      setDay(weekId, day, { [key]: state });
+    });
+    const label = document.createElement('label');
+    label.setAttribute('for', cb.id);
+    label.textContent = text;
+    li.append(cb, label);
+    ul.appendChild(li);
+  });
+  return ul;
+}
 
-export function CopyButton(text){const btn=document.createElement('button');btn.textContent='Copy';btn.addEventListener('click',()=>{navigator.clipboard.writeText(text).then(()=>Toast('Copied'));});return btn;}
+// Timer component using timers.js
+export function Timer({ seconds, weekId, day }) {
+  const data = getDay(weekId, day);
+  const last = data.timer || seconds;
+  const container = document.createElement('div');
+  container.className = 'timer';
+  const display = document.createElement('div');
+  display.className = 'timer-display';
+  const controls = document.createElement('div');
+  const startBtn = document.createElement('button');
+  startBtn.textContent = 'Start';
+  const resetBtn = document.createElement('button');
+  resetBtn.textContent = 'Reset';
+  controls.append(startBtn, resetBtn);
+  container.append(display, controls);
+
+  const timer = createTimer({ seconds: last });
+  timer.onTick((t) => {
+    const m = String(Math.floor(t / 60)).padStart(2, '0');
+    const s = String(t % 60).padStart(2, '0');
+    display.textContent = `${m}:${s}`;
+  });
+  timer.onComplete(() => Toast('Done'));
+
+  startBtn.addEventListener('click', () => {
+    if (timer.running) {
+      timer.pause();
+      startBtn.textContent = 'Start';
+    } else {
+      timer.start();
+      startBtn.textContent = 'Pause';
+    }
+  });
+  resetBtn.addEventListener('click', () => {
+    timer.reset();
+    startBtn.textContent = 'Start';
+  });
+
+  setDay(weekId, day, { timer: last });
+  return container;
+}
+
+// Quiz wrapper
+export function Quiz({ questions, weekId, day }) {
+  const div = document.createElement('div');
+  div.className = 'quiz';
+  renderQuiz(div, questions, { weekId, day });
+  return div;
+}
+
+// Flashcards wrapper
+export function Flashcards({ cards, weekId, day }) {
+  const div = document.createElement('div');
+  div.className = 'flashcards';
+  renderFlashcards(div, cards, { weekId, day });
+  return div;
+}
+
+// Rubric component
+export function Rubric({ dimensions, weekId, day }) {
+  const data = getDay(weekId, day);
+  const state = data.rubric || {};
+  const div = document.createElement('div');
+  div.className = 'rubric';
+  dimensions.forEach((d) => {
+    const row = document.createElement('div');
+    row.className = 'rubric-row';
+    const label = document.createElement('label');
+    label.textContent = d.dimension;
+    const select = document.createElement('select');
+    d.levels.forEach((l) => {
+      const opt = document.createElement('option');
+      opt.value = l;
+      opt.textContent = l;
+      if (state[d.dimension] === l) opt.selected = true;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', () => {
+      state[d.dimension] = select.value;
+      setDay(weekId, day, { rubric: state });
+    });
+    row.append(label, select);
+    div.appendChild(row);
+  });
+  return div;
+}
+

--- a/scripts/ui/flashcards.js
+++ b/scripts/ui/flashcards.js
@@ -1,2 +1,69 @@
-import {Toast} from './components.js';
-export function FlashcardEngine(node,cards){let i=0,front=true;const card=document.createElement('div');card.className='flashcard';node.appendChild(card);function render(){const c=cards[i];card.textContent=front?c.term:c.definition;}render();card.addEventListener('click',()=>{front=!front;render();});const next=document.createElement('button');next.textContent='Next';next.addEventListener('click',()=>{i=(i+1)%cards.length;front=true;render();});node.appendChild(next);}
+import {getDay, setDay} from './storage.js';
+
+// Simple flashcard engine with spaced repetition buckets
+export function renderFlashcards(node, cards, { weekId, day }) {
+  const data = getDay(weekId, day);
+  const buckets = data.flash || {};
+
+  // init bucket state
+  cards.forEach(c => {
+    if (!buckets[c.term]) buckets[c.term] = 'learning';
+  });
+  setDay(weekId, day, { flash: buckets });
+
+  let index = 0;
+  let front = true;
+
+  const card = document.createElement('div');
+  card.className = 'flashcard';
+  node.appendChild(card);
+
+  const controls = document.createElement('div');
+  const prev = document.createElement('button');
+  prev.textContent = 'Prev';
+  const next = document.createElement('button');
+  next.textContent = 'Next';
+  const hard = document.createElement('button');
+  hard.textContent = 'Hard';
+  const easy = document.createElement('button');
+  easy.textContent = 'Easy';
+  controls.append(prev, next, hard, easy);
+  node.appendChild(controls);
+
+  const counter = document.createElement('p');
+  node.appendChild(counter);
+
+  function render() {
+    const c = cards[index];
+    card.textContent = front ? c.term : c.definition;
+    updateCounts();
+  }
+
+  function updateCounts() {
+    const counts = { learning: 0, review: 0, mastered: 0 };
+    Object.values(buckets).forEach(b => counts[b]++);
+    counter.textContent = `Learning ${counts.learning} · Review ${counts.review} · Mastered ${counts.mastered}`;
+  }
+
+  card.addEventListener('click', () => { front = !front; render(); });
+  next.addEventListener('click', () => { index = (index + 1) % cards.length; front = true; render(); });
+  prev.addEventListener('click', () => { index = (index - 1 + cards.length) % cards.length; front = true; render(); });
+
+  hard.addEventListener('click', () => {
+    const term = cards[index].term;
+    buckets[term] = 'learning';
+    setDay(weekId, day, { flash: buckets });
+    updateCounts();
+  });
+
+  easy.addEventListener('click', () => {
+    const term = cards[index].term;
+    const state = buckets[term];
+    buckets[term] = state === 'learning' ? 'review' : 'mastered';
+    setDay(weekId, day, { flash: buckets });
+    updateCounts();
+  });
+
+  render();
+}
+

--- a/scripts/ui/quiz.js
+++ b/scripts/ui/quiz.js
@@ -1,2 +1,64 @@
-import {Toast} from './components.js';
-export function renderQuiz(node, q){let correct=0;const div=document.createElement('div');q.questions.forEach((qq,idx)=>{const p=document.createElement('p');p.textContent=qq.q;div.appendChild(p);qq.choices.forEach((c,i)=>{const btn=document.createElement('button');btn.textContent=c;btn.addEventListener('click',()=>{if(i===qq.answer){btn.classList.add('correct');correct++;Toast('Correct');}else{btn.classList.add('wrong');Toast('Try again');} Array.from(btn.parentElement.children).forEach(b=>b.disabled=true);});div.appendChild(btn);});});node.appendChild(div);return()=>correct;}
+import {getDay, setDay} from './storage.js';
+
+// Render multiple-choice quiz questions. State persists per day.
+export function renderQuiz(node, questions, { weekId, day }) {
+  const data = getDay(weekId, day);
+  let score = 0;
+  let answered = 0;
+
+  const stored = data.quiz;
+  const container = document.createElement('div');
+
+  questions.forEach((q, qi) => {
+    const wrap = document.createElement('div');
+    wrap.className = 'quiz-question';
+    const p = document.createElement('p');
+    p.textContent = q.q;
+    wrap.appendChild(p);
+
+    q.choices.forEach((choice, idx) => {
+      const btn = document.createElement('button');
+      btn.textContent = choice;
+      btn.addEventListener('click', () => {
+        if (btn.disabled) return;
+        answered++;
+        if (idx === q.answer) {
+          btn.classList.add('correct');
+          score++;
+          showToast('Correct');
+        } else {
+          btn.classList.add('wrong');
+          showToast('Wrong');
+        }
+        Array.from(btn.parentNode.querySelectorAll('button')).forEach(b => b.disabled = true);
+        if (answered === questions.length) finalize();
+      });
+      wrap.appendChild(btn);
+    });
+    container.appendChild(wrap);
+  });
+
+  const result = document.createElement('p');
+  container.appendChild(result);
+
+  function finalize() {
+    result.textContent = `Score: ${score} / ${questions.length}`;
+    setDay(weekId, day, { quiz: { total: questions.length, correct: score } });
+  }
+
+  if (stored) {
+    // show stored score if already taken
+    result.textContent = `Last score: ${stored.correct} / ${stored.total}`;
+  }
+
+  node.appendChild(container);
+}
+
+function showToast(msg) {
+  const t = document.createElement('div');
+  t.className = 'toast';
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(() => t.remove(), 2000);
+}
+

--- a/scripts/ui/storage.js
+++ b/scripts/ui/storage.js
@@ -1,6 +1,47 @@
-const KEY='progress';
-export function load(){try{return JSON.parse(localStorage.getItem(KEY))||{weeks:{}};}catch{return{weeks:{}};}}
-export function save(data){localStorage.setItem(KEY,JSON.stringify(data));}
-export function getWeek(id){const data=load();if(!data.weeks[id])data.weeks[id]={};return data.weeks[id];}
-export function setWeek(id,week){const data=load();data.weeks[id]=week;save(data);}
-export function reset(){localStorage.removeItem(KEY);}
+// LocalStorage helpers with namespaced week/day keys
+
+const KEY = 'progress';
+
+function load() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) || { weeks: {} };
+  } catch {
+    return { weeks: {} };
+  }
+}
+
+function save(data) {
+  localStorage.setItem(KEY, JSON.stringify(data));
+}
+
+// Get week-level data object
+export function getProgress(weekId) {
+  const data = load();
+  if (!data.weeks[weekId]) data.weeks[weekId] = { days: {} };
+  return data.weeks[weekId];
+}
+
+export function setProgress(weekId, weekData) {
+  const data = load();
+  data.weeks[weekId] = weekData;
+  save(data);
+}
+
+// Get day-level object; ensures path exists
+export function getDay(weekId, day) {
+  const week = getProgress(weekId);
+  if (!week.days[day]) week.days[day] = {};
+  setProgress(weekId, week);
+  return week.days[day];
+}
+
+export function setDay(weekId, day, obj) {
+  const week = getProgress(weekId);
+  week.days[day] = { ...week.days[day], ...obj };
+  setProgress(weekId, week);
+}
+
+export function reset() {
+  localStorage.removeItem(KEY);
+}
+

--- a/scripts/ui/timers.js
+++ b/scripts/ui/timers.js
@@ -1,3 +1,79 @@
-// Simple countdown helper
-export function countdown(seconds, onTick, onDone){let t=seconds;onTick(t);const i=setInterval(()=>{t--;onTick(t);if(t<=0){clearInterval(i);beep();onDone&&onDone();}},1000);return()=>clearInterval(i);} 
-function beep(){try{const ctx=new (window.AudioContext||window.webkitAudioContext)();const osc=ctx.createOscillator();osc.type='sine';osc.frequency.setValueAtTime(440,ctx.currentTime);osc.connect(ctx.destination);osc.start();osc.stop(ctx.currentTime+0.2);}catch{}}
+// Countdown timer utility with start/pause/reset API
+
+export function createTimer({ seconds }) {
+  let remaining = seconds;
+  let interval = null;
+  const tickHandlers = [];
+  const doneHandlers = [];
+
+  function emitTick() {
+    tickHandlers.forEach((h) => h(remaining));
+  }
+
+  function emitDone() {
+    doneHandlers.forEach((h) => h());
+  }
+
+  function start() {
+    if (interval) return;
+    interval = setInterval(() => {
+      remaining--;
+      emitTick();
+      if (remaining <= 0) {
+        pause();
+        beep();
+        emitDone();
+      }
+    }, 1000);
+  }
+
+  function pause() {
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+  }
+
+  function reset(sec = seconds) {
+    pause();
+    remaining = sec;
+    emitTick();
+  }
+
+  function onTick(cb) {
+    tickHandlers.push(cb);
+  }
+
+  function onComplete(cb) {
+    doneHandlers.push(cb);
+  }
+
+  emitTick();
+
+  return {
+    start,
+    pause,
+    reset,
+    onTick,
+    onComplete,
+    get running() {
+      return Boolean(interval);
+    },
+  };
+}
+
+// simple beep using WebAudio
+function beep() {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(880, ctx.currentTime);
+    osc.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.15);
+  } catch {
+    /* no audio support */
+  }
+}
+

--- a/styles/components.css
+++ b/styles/components.css
@@ -7,10 +7,19 @@
 .accordion-content.open{display:block;}
 .progress-ring{width:48px;height:48px;}
 .toast{position:fixed;bottom:var(--space-4);left:50%;transform:translateX(-50%);background:var(--ink);color:var(--card);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);}
+.copy{margin-left:var(--space-2);}
 .tabs{display:flex;border-bottom:1px solid var(--shadow);} .tabs button{flex:1;background:none;color:inherit;padding:var(--space-2);} .tabs button[aria-selected="true"]{border-bottom:2px solid var(--tint);}
 .modal{position:fixed;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.4);} .modal.open{display:flex;} .modal-content{background:var(--card);padding:var(--space-4);border-radius:var(--radius-lg);max-width:90%;}
 .checklist li{display:flex;align-items:center;margin-bottom:var(--space-2);} .checklist input{margin-right:var(--space-2);} 
 .timer-display{font-size:2rem;text-align:center;margin-bottom:var(--space-2);} 
-.quiz-question{margin-bottom:var(--space-3);} 
-.flashcard{border:1px solid var(--shadow);padding:var(--space-4);text-align:center;border-radius:var(--radius-lg);cursor:pointer;} 
-.rubric-row{display:flex;align-items:center;margin-bottom:var(--space-2);} .rubric-row label{flex:1;} .rubric-row select{margin-left:var(--space-2);} 
+.quiz-question{margin-bottom:var(--space-3);}
+.flashcard{border:1px solid var(--shadow);padding:var(--space-4);text-align:center;border-radius:var(--radius-lg);cursor:pointer;}
+.rubric-row{display:flex;align-items:center;margin-bottom:var(--space-2);} .rubric-row label{flex:1;} .rubric-row select{margin-left:var(--space-2);}
+.topbar{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);}
+.glance{display:flex;align-items:center;gap:var(--space-3);margin:var(--space-3) 0;}
+.day-footer{display:flex;gap:var(--space-2);margin-top:var(--space-4);}
+.day-footer button.success{background:var(--tint);color:var(--card);}
+
+@media print{
+  .topbar,.day-footer,.glance .progress-ring{display:none;}
+}

--- a/weeks/week.js
+++ b/weeks/week.js
@@ -1,19 +1,217 @@
-import {Accordion,Card,Checklist,Timer,Quiz,Flashcards,Rubric,CopyButton} from '../scripts/ui/components.js';
-import {initRouter} from '../scripts/router.js';
+import {Accordion, Checklist, Timer, Quiz, Flashcards, Rubric, CopyButton, ProgressRing} from '../scripts/ui/components.js';
+import {getProgress, getDay, setDay} from '../scripts/ui/storage.js';
 
-async function init(){const id=location.pathname.match(/week(\d+)/)[1];const res=await fetch(`../data/week${id}.json`);const week=await res.json();document.title=week.title;document.querySelector('h1').textContent=week.title;const goalsCard=Card('Week goals',buildGoals(week.goals));document.querySelector('#goals').appendChild(goalsCard);week.days.forEach(d=>renderDay(d));initRouter(hash=>{if(hash.startsWith('day-')){document.getElementById(hash).click();}});}
+const weekId = location.pathname.match(/week(\d+)/)[1];
 
-function buildGoals(goals){const ul=document.createElement('ul');goals.forEach(g=>{const li=document.createElement('li');li.textContent=g;ul.appendChild(li);});return ul;}
+async function init() {
+  const res = await fetch(`../data/week${weekId}.json`);
+  const week = await res.json();
+  document.getElementById('week-title').textContent = week.title;
+  document.title = week.title;
 
-function renderDay(day){const content=document.createElement('div');const focus=document.createElement('p');focus.textContent=day.focus;content.appendChild(focus);
-  if(day.vocabulary){const vocab=document.createElement('ul');day.vocabulary.forEach(v=>{const li=document.createElement('li');li.textContent=v;vocab.appendChild(li);});content.appendChild(vocab);} 
-  day.activities&&day.activities.forEach(a=>{if(a.type==='checklist')content.appendChild(Checklist(a.items));});
-  if(day.templates){const div=document.createElement('div');day.templates.forEach(t=>{const p=document.createElement('p');p.textContent=t;div.appendChild(p);div.appendChild(CopyButton(t));});content.appendChild(div);} 
-  if(day.quiz){const div=document.createElement('div');div.id=`quiz-${day.day}`;content.appendChild(div);Quiz(div,day.quiz.questions);} 
-  if(day.flashcards){const div=document.createElement('div');Flashcards(div,day.flashcards);content.appendChild(div);} 
-  if(day.homework){const hw=Checklist(day.homework);content.appendChild(hw);} 
-  if(day.rubric){content.appendChild(Rubric(day.rubric));}
-  const acc=Accordion({id:`day-${day.day}`,title:`Day ${day.day}: ${day.title}`},content);
-  document.querySelector('#days').appendChild(acc);}
+  renderGoals(week.goals);
+  renderDays(week);
+  updateGlance();
+
+  const hash = location.hash.match(/day-(\d+)/);
+  const q = new URLSearchParams(location.search).get('d');
+  if (hash) openDay(hash[1]);
+  else if (q) openDay(q);
+}
+
+function renderGoals(goals) {
+  const card = document.createElement('div');
+  card.className = 'card';
+  const h = document.createElement('h2');
+  h.textContent = 'Week goals';
+  card.appendChild(h);
+  const ul = document.createElement('ul');
+  goals.forEach(g => {
+    const li = document.createElement('li');
+    li.textContent = g;
+    ul.appendChild(li);
+  });
+  card.appendChild(ul);
+  document.getElementById('goals').appendChild(card);
+}
+
+function renderDays(week) {
+  const container = document.getElementById('days');
+  week.days.forEach((day, idx) => {
+    const content = document.createElement('div');
+    content.className = 'day';
+
+    const focus = document.createElement('p');
+    focus.textContent = day.focus;
+    content.appendChild(focus);
+
+    // vocabulary
+    if (day.vocabulary) {
+      const wrap = document.createElement('div');
+      const ul = document.createElement('ul');
+      day.vocabulary.forEach(v => {
+        const li = document.createElement('li');
+        li.textContent = v;
+        ul.appendChild(li);
+      });
+      wrap.appendChild(ul);
+
+      const copy = CopyButton(day.vocabulary.join(', '));
+      wrap.appendChild(copy);
+
+      if (day.usageExamples) {
+        const toggle = document.createElement('button');
+        toggle.textContent = 'Show usage examples';
+        const exWrap = document.createElement('ul');
+        exWrap.hidden = true;
+        day.usageExamples.forEach(ex => {
+          const li = document.createElement('li');
+          li.textContent = ex;
+          li.appendChild(CopyButton(ex));
+          exWrap.appendChild(li);
+        });
+        toggle.addEventListener('click', () => {
+          const vis = exWrap.hidden;
+          exWrap.hidden = !vis;
+          toggle.textContent = vis ? 'Hide usage examples' : 'Show usage examples';
+        });
+        wrap.appendChild(toggle);
+        wrap.appendChild(exWrap);
+      }
+      content.appendChild(wrap);
+    }
+
+    // activities
+    day.activities && day.activities.forEach(a => {
+      const card = document.createElement('div');
+      card.className = 'card activity';
+      const h = document.createElement('h3');
+      h.textContent = a.title;
+      card.appendChild(h);
+      if (a.instructions) {
+        const p = document.createElement('p');
+        p.textContent = a.instructions;
+        card.appendChild(p);
+      }
+      if (a.type === 'checklist') {
+        card.appendChild(Checklist({ items: a.items, weekId, day: day.day, key: 'checklist' }));
+      }
+      if (a.type === 'timer') {
+        const match = a.instructions && a.instructions.match(/(\d+)[-\s]?minute/);
+        const secs = match ? parseInt(match[1], 10) * 60 : 300;
+        card.appendChild(Timer({ seconds: secs, weekId, day: day.day }));
+      }
+      content.appendChild(card);
+    });
+
+    // templates
+    if (day.templates) {
+      const div = document.createElement('div');
+      div.className = 'card';
+      const h = document.createElement('h3');
+      h.textContent = 'Templates';
+      div.appendChild(h);
+      day.templates.forEach(t => {
+        const p = document.createElement('p');
+        p.textContent = t;
+        p.appendChild(CopyButton(t));
+        div.appendChild(p);
+      });
+      content.appendChild(div);
+    }
+
+    // quiz
+    if (day.quiz) {
+      content.appendChild(Quiz({ questions: day.quiz.questions, weekId, day: day.day }));
+    }
+
+    // flashcards
+    if (day.flashcards) {
+      content.appendChild(Flashcards({ cards: day.flashcards, weekId, day: day.day }));
+    }
+
+    // homework
+    if (day.homework) {
+      const hw = Checklist({ items: day.homework, weekId, day: day.day, key: 'homework' });
+      const wrapper = document.createElement('div');
+      wrapper.className = 'card';
+      const h = document.createElement('h3');
+      h.textContent = 'Homework';
+      wrapper.append(h, hw);
+      content.appendChild(wrapper);
+    }
+
+    // rubric
+    if (day.rubric) {
+      const r = Rubric({ dimensions: day.rubric, weekId, day: day.day });
+      const wrap = document.createElement('div');
+      wrap.className = 'card';
+      const h = document.createElement('h3');
+      h.textContent = 'Rubric';
+      wrap.append(h, r);
+      content.appendChild(wrap);
+    }
+
+    // footer nav
+    const footer = document.createElement('div');
+    footer.className = 'day-footer';
+    const prevBtn = document.createElement('button');
+    prevBtn.textContent = 'Prev Day';
+    prevBtn.disabled = idx === 0;
+    prevBtn.addEventListener('click', () => openDay(day.day - 1));
+    const nextBtn = document.createElement('button');
+    nextBtn.textContent = 'Next Day';
+    nextBtn.disabled = idx === week.days.length - 1;
+    nextBtn.addEventListener('click', () => openDay(day.day + 1));
+    const doneBtn = document.createElement('button');
+    doneBtn.textContent = 'Mark Day Complete';
+    const dayData = getDay(weekId, day.day);
+    if (dayData.done) doneBtn.classList.add('success');
+    doneBtn.addEventListener('click', () => {
+      const d = getDay(weekId, day.day);
+      d.done = !d.done;
+      setDay(weekId, day.day, d);
+      doneBtn.classList.toggle('success', d.done);
+      updateGlance();
+    });
+    footer.append(prevBtn, nextBtn, doneBtn);
+    content.appendChild(footer);
+
+    const acc = Accordion({ id: `day-${day.day}`, title: `Day ${day.day}: ${day.title}` }, content);
+    container.appendChild(acc);
+  });
+}
+
+function updateGlance() {
+  const progress = getProgress(weekId);
+  const days = Object.values(progress.days || {});
+  const completed = days.filter(d => d.done).length;
+  let vocab = 0;
+  let quizzes = 0;
+  days.forEach(d => {
+    if (d.flash) {
+      Object.values(d.flash).forEach(v => { if (v === 'mastered') vocab++; });
+    }
+    if (d.quiz && d.quiz.correct === d.quiz.total) quizzes++;
+  });
+  const wrap = document.getElementById('glance');
+  wrap.innerHTML = '';
+  const p = document.createElement('p');
+  p.textContent = `Days ${completed} · Vocab mastered ${vocab} · Quizzes passed ${quizzes}`;
+  wrap.appendChild(p);
+  wrap.appendChild(ProgressRing((completed / 7) * 100));
+}
+
+export function openDay(n) {
+  const btn = document.querySelector(`#day-${n} > h2 > button`);
+  if (btn) {
+    btn.click();
+    document.getElementById(`day-${n}`).scrollIntoView();
+  }
+}
 
 init();
+
+// expose helper
+window.openDay = openDay;
+

--- a/weeks/week1.html
+++ b/weeks/week1.html
@@ -10,11 +10,14 @@
 <title>Week 1</title>
 </head>
 <body>
-<header class="stack"><a href="../index.html">← Back</a></header>
+<header class="topbar">
+  <a href="../index.html" class="back">← Back</a>
+  <h1 id="week-title" class="muted"></h1>
+</header>
 <main class="stack">
-<h1 class="muted">Week 1</h1>
-<div id="goals" class="stack"></div>
-<div id="days" class="stack"></div>
+  <section id="goals" class="stack"></section>
+  <section id="glance" class="glance" aria-label="Week progress"></section>
+  <div id="days" class="stack"></div>
 </main>
 <script type="module" src="week.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add full Week 1 JSON with detailed daily activities, quizzes, and flashcards
- build reusable UI components with localStorage persistence and timers, quiz, and flashcard engines
- render Week 1 page from JSON with accordions, at-a-glance progress, and day navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae68d185b0832b9e93a03605997de4