### PR TITLE
feat: implement week 1 interactive flow

### DIFF
--- a/scripts/ui/components.js
+++ b/scripts/ui/components.js
@@ -1,13 +1,10 @@
-// Core UI component helpers
-// Components are kept minimal and data-driven. Persistence is handled via
-// storage.js using week/day scoped keys.
+// Reusable UI components for week pages
+// Components are framework-agnostic and rely on consumers to provide
+// storage getters/setters. Only minimal styling is assumed.
 
-import {getDay, setDay} from './storage.js';
-import {createTimer} from './timers.js';
-import {renderQuiz} from './quiz.js';
-import {renderFlashcards} from './flashcards.js';
+import { createTimer } from './timers.js';
 
-// Utility: toast message
+// Toast helper ---------------------------------------------------------
 export function Toast(msg) {
   const t = document.createElement('div');
   t.className = 'toast';
@@ -16,7 +13,7 @@ export function Toast(msg) {
   setTimeout(() => t.remove(), 2000);
 }
 
-// Copy button with toast feedback
+// Copy button with toast feedback -------------------------------------
 export function CopyButton(text) {
   const btn = document.createElement('button');
   btn.className = 'copy';
@@ -27,40 +24,70 @@ export function CopyButton(text) {
   return btn;
 }
 
-// Accessible accordion section
-export function Accordion({ id, title }, content) {
+// Accordion ------------------------------------------------------------
+// id should be unique per page (e.g. `day-1`); the returned element is a
+// `<section>` that contains a trigger button and a content panel. The
+// trigger emits `accordion:open`/`accordion:close` custom events.
+export function Accordion({ id, title }, content, { startOpen = false } = {}) {
   const section = document.createElement('section');
   section.className = 'accordion';
 
+  const trigger = document.createElement('button');
+  trigger.className = 'acc-trigger';
+  trigger.id = `acc-trigger-${id}`;
+  trigger.setAttribute('aria-controls', `acc-panel-${id}`);
+  trigger.setAttribute('aria-expanded', startOpen ? 'true' : 'false');
+  const titleSpan = document.createElement('span');
+  titleSpan.className = 'acc-title';
+  titleSpan.textContent = title;
+  const badgeSpan = document.createElement('span');
+  badgeSpan.className = 'badges';
+  trigger.append(titleSpan, badgeSpan);
+
   const header = document.createElement('h2');
-  const btn = document.createElement('button');
-  btn.id = id;
-  btn.setAttribute('aria-expanded', 'false');
-  btn.setAttribute('aria-controls', `${id}-panel`);
-  btn.innerHTML = `<span>${title}</span>`;
-  header.appendChild(btn);
+  header.appendChild(trigger);
 
   const panel = document.createElement('div');
-  panel.id = `${id}-panel`;
-  panel.hidden = true;
-  panel.className = 'accordion-content';
+  panel.id = `acc-panel-${id}`;
+  panel.className = 'acc-panel';
+  panel.hidden = !startOpen;
   panel.setAttribute('role', 'region');
-  panel.setAttribute('aria-labelledby', id);
+  panel.setAttribute('aria-labelledby', trigger.id);
+  if (content) panel.appendChild(content);
 
-  btn.addEventListener('click', () => {
-    const open = btn.getAttribute('aria-expanded') === 'true';
-    btn.setAttribute('aria-expanded', String(!open));
-    panel.hidden = open;
-    if (!open) panel.focus();
+  function open() {
+    trigger.setAttribute('aria-expanded', 'true');
+    panel.hidden = false;
+    trigger.dispatchEvent(new CustomEvent('accordion:open', { bubbles: true }));
+  }
+
+  function close() {
+    trigger.setAttribute('aria-expanded', 'false');
+    panel.hidden = true;
+    trigger.dispatchEvent(new CustomEvent('accordion:close', { bubbles: true }));
+  }
+
+  trigger.addEventListener('click', () => {
+    const expanded = trigger.getAttribute('aria-expanded') === 'true';
+    expanded ? close() : open();
   });
 
-  if (content) panel.appendChild(content);
+  // keyboard support (Space/Enter)
+  trigger.addEventListener('keydown', (e) => {
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      trigger.click();
+    }
+  });
+
   section.append(header, panel);
   return section;
 }
 
-// SVG progress ring
-export function ProgressRing(percent) {
+// Progress ring -------------------------------------------------------
+// Returns an SVG element representing `percent` (0–100). The element has an
+// `.update(p)` method to change the value.
+export function ProgressRing(percent = 0) {
   const circ = 2 * Math.PI * 16;
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.setAttribute('viewBox', '0 0 36 36');
@@ -77,118 +104,297 @@ export function ProgressRing(percent) {
   fg.setAttribute('stroke', 'var(--tint)');
   fg.setAttribute('stroke-width', '2');
   fg.setAttribute('fill', 'none');
-  fg.setAttribute('stroke-dasharray', `${(percent / 100) * circ} ${circ}`);
+
+  function set(p) {
+    const dash = (p / 100) * circ;
+    fg.setAttribute('stroke-dasharray', `${dash} ${circ}`);
+  }
+
+  svg.update = set;
+  set(percent);
 
   svg.append(bg, fg);
   return svg;
 }
 
-// Checklist component; items is array of strings. Persist state per item.
-export function Checklist({ items, weekId, day, key }) {
-  const data = getDay(weekId, day);
-  const state = data[key] || {};
+// Checklist -----------------------------------------------------------
+// `getState` and `setState` allow callers to persist data.
+export function Checklist({ items, getState, setState }) {
+  const state = getState() || {};
   const ul = document.createElement('ul');
   ul.className = 'checklist';
 
-  items.forEach((text) => {
+  items.forEach((label) => {
     const li = document.createElement('li');
     const cb = document.createElement('input');
     cb.type = 'checkbox';
-    cb.checked = Boolean(state[text]);
-    cb.id = `${key}-${text}`;
+    cb.checked = Boolean(state[label]);
+    cb.id = `chk-${label}`;
     cb.addEventListener('change', () => {
-      state[text] = cb.checked;
-      setDay(weekId, day, { [key]: state });
+      state[label] = cb.checked;
+      setState(state);
+      ul.dispatchEvent(new Event('change'));
     });
-    const label = document.createElement('label');
-    label.setAttribute('for', cb.id);
-    label.textContent = text;
-    li.append(cb, label);
+    const lab = document.createElement('label');
+    lab.setAttribute('for', cb.id);
+    lab.textContent = label;
+    li.append(cb, lab);
     ul.appendChild(li);
   });
+
   return ul;
 }
 
-// Timer component using timers.js
-export function Timer({ seconds, weekId, day }) {
-  const data = getDay(weekId, day);
-  const last = data.timer || seconds;
+// Timer ---------------------------------------------------------------
+// Simple countdown timer. Persists remaining seconds to `storageKey` in
+// localStorage whenever changed or reset.
+export function Timer({ seconds = 60, storageKey, onComplete }) {
+  const stored = parseInt(localStorage.getItem(storageKey) || seconds, 10);
+  let remaining = stored;
+
   const container = document.createElement('div');
   container.className = 'timer';
   const display = document.createElement('div');
   display.className = 'timer-display';
   const controls = document.createElement('div');
-  const startBtn = document.createElement('button');
-  startBtn.textContent = 'Start';
-  const resetBtn = document.createElement('button');
-  resetBtn.textContent = 'Reset';
-  controls.append(startBtn, resetBtn);
+  controls.className = 'timer-controls';
+  const start = document.createElement('button');
+  start.textContent = 'Start';
+  const reset = document.createElement('button');
+  reset.textContent = 'Reset';
+  controls.append(start, reset);
   container.append(display, controls);
 
-  const timer = createTimer({ seconds: last });
+  const timer = createTimer({ seconds: remaining });
   timer.onTick((t) => {
+    remaining = t;
+    localStorage.setItem(storageKey, String(remaining));
     const m = String(Math.floor(t / 60)).padStart(2, '0');
     const s = String(t % 60).padStart(2, '0');
     display.textContent = `${m}:${s}`;
   });
-  timer.onComplete(() => Toast('Done'));
+  timer.onComplete(() => {
+    Toast('Time\u2019s up');
+    onComplete && onComplete();
+  });
 
-  startBtn.addEventListener('click', () => {
+  start.addEventListener('click', () => {
     if (timer.running) {
       timer.pause();
-      startBtn.textContent = 'Start';
+      start.textContent = 'Start';
     } else {
       timer.start();
-      startBtn.textContent = 'Pause';
+      start.textContent = 'Pause';
     }
   });
-  resetBtn.addEventListener('click', () => {
-    timer.reset();
-    startBtn.textContent = 'Start';
+
+  reset.addEventListener('click', () => {
+    timer.reset(seconds);
+    start.textContent = 'Start';
+    localStorage.setItem(storageKey, String(seconds));
   });
 
-  setDay(weekId, day, { timer: last });
   return container;
 }
 
-// Quiz wrapper
-export function Quiz({ questions, weekId, day }) {
-  const div = document.createElement('div');
-  div.className = 'quiz';
-  renderQuiz(div, questions, { weekId, day });
-  return div;
+// Quiz ----------------------------------------------------------------
+// Renders multiple-choice questions. `storageGet`/`storageSet` abstract
+// persistence.
+export function Quiz({ questions, storageGet, storageSet }) {
+  const state = storageGet() || { total: questions.length, correct: 0, best: 0 };
+  const form = document.createElement('form');
+  form.className = 'quiz';
+
+  questions.forEach((q, qi) => {
+    const field = document.createElement('fieldset');
+    const legend = document.createElement('legend');
+    legend.textContent = q.q;
+    field.appendChild(legend);
+
+    q.choices.forEach((choice, ci) => {
+      const id = `q${qi}c${ci}`;
+      const label = document.createElement('label');
+      label.setAttribute('for', id);
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = `q${qi}`;
+      input.id = id;
+      input.value = String(ci);
+      label.append(input, document.createTextNode(choice));
+      field.appendChild(label);
+    });
+
+    form.appendChild(field);
+  });
+
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Submit';
+  const retry = document.createElement('button');
+  retry.type = 'button';
+  retry.textContent = 'Retry';
+  retry.hidden = true;
+  const result = document.createElement('p');
+  form.append(submit, retry, result);
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    let correct = 0;
+    questions.forEach((q, qi) => {
+      const selected = form.querySelector(`input[name="q${qi}"]:checked`);
+      const field = form.querySelectorAll('fieldset')[qi];
+      field.querySelectorAll('label').forEach((lab, idx) => {
+        lab.classList.remove('correct', 'wrong');
+        const inpt = lab.querySelector('input');
+        if (inpt.checked) {
+          if (idx === q.answer) {
+            lab.classList.add('correct');
+            correct++;
+          } else lab.classList.add('wrong');
+        }
+      });
+    });
+    state.total = questions.length;
+    state.correct = correct;
+    if (correct > state.best) state.best = correct;
+    storageSet(state);
+    result.textContent = `Score: ${correct}/${questions.length}`;
+    submit.disabled = true;
+    retry.hidden = false;
+    form.dispatchEvent(new Event('change')); // notify progress
+  });
+
+  retry.addEventListener('click', () => {
+    submit.disabled = false;
+    retry.hidden = true;
+    result.textContent = '';
+    form.querySelectorAll('input[type="radio"]').forEach((i) => (i.checked = false));
+    form.querySelectorAll('label').forEach((l) => l.classList.remove('correct', 'wrong'));
+  });
+
+  if (state.correct) {
+    result.textContent = `Last score: ${state.correct}/${state.total}`;
+    submit.disabled = true;
+    retry.hidden = false;
+  }
+
+  return form;
 }
 
-// Flashcards wrapper
-export function Flashcards({ cards, weekId, day }) {
-  const div = document.createElement('div');
-  div.className = 'flashcards';
-  renderFlashcards(div, cards, { weekId, day });
-  return div;
+// Flashcards -----------------------------------------------------------
+// Simple spaced-repetition flashcards. `cards` = [{term,definition}].
+// Buckets: learning -> review -> mastered. Hard = move back (if possible),
+// Easy = move forward. State persisted via storage functions.
+export function Flashcards({ cards, storageGet, storageSet }) {
+  const state = storageGet() || {}; // term -> bucket
+  let idx = 0;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'flashcards';
+
+  const header = document.createElement('div');
+  header.className = 'flash-header';
+  const counts = document.createElement('span');
+  header.appendChild(counts);
+
+  const card = document.createElement('div');
+  card.className = 'flash-card';
+  const term = document.createElement('div');
+  term.className = 'term';
+  const def = document.createElement('div');
+  def.className = 'def';
+  def.hidden = true;
+  card.append(term, def);
+
+  const prev = document.createElement('button');
+  prev.textContent = 'Prev';
+  const next = document.createElement('button');
+  next.textContent = 'Next';
+  const flip = document.createElement('button');
+  flip.textContent = 'Flip';
+  const hard = document.createElement('button');
+  hard.textContent = 'Hard';
+  const easy = document.createElement('button');
+  easy.textContent = 'Easy';
+  const controls = document.createElement('div');
+  controls.className = 'flash-controls';
+  controls.append(prev, next, flip, hard, easy);
+
+  wrap.append(header, card, controls);
+
+  function updateCounts() {
+    let l = 0,
+      r = 0,
+      m = 0;
+    Object.values(state).forEach((b) => {
+      if (b === 'mastered') m++;
+      else if (b === 'review') r++;
+      else l++;
+    });
+    counts.textContent = `${l} • ${r} • ${m}`;
+    storageSet(state);
+    wrap.dispatchEvent(new Event('change')); // update progress
+  }
+
+  function show() {
+    const c = cards[idx];
+    term.textContent = c.term;
+    def.textContent = c.definition;
+    def.hidden = true;
+  }
+
+  flip.addEventListener('click', () => {
+    def.hidden = !def.hidden;
+  });
+  prev.addEventListener('click', () => {
+    idx = (idx - 1 + cards.length) % cards.length;
+    show();
+  });
+  next.addEventListener('click', () => {
+    idx = (idx + 1) % cards.length;
+    show();
+  });
+  hard.addEventListener('click', () => {
+    const termTxt = cards[idx].term;
+    const bucket = state[termTxt] || 'learning';
+    state[termTxt] = bucket === 'review' ? 'learning' : bucket;
+    if (bucket === 'mastered') state[termTxt] = 'review';
+    updateCounts();
+  });
+  easy.addEventListener('click', () => {
+    const termTxt = cards[idx].term;
+    const bucket = state[termTxt] || 'learning';
+    state[termTxt] = bucket === 'learning' ? 'review' : 'mastered';
+    updateCounts();
+  });
+
+  show();
+  updateCounts();
+
+  return wrap;
 }
 
-// Rubric component
-export function Rubric({ dimensions, weekId, day }) {
-  const data = getDay(weekId, day);
-  const state = data.rubric || {};
+// Rubric --------------------------------------------------------------
+export function Rubric({ dimensions, getState, setState }) {
+  const state = getState() || {};
   const div = document.createElement('div');
   div.className = 'rubric';
-  dimensions.forEach((d) => {
+  dimensions.forEach((dim) => {
     const row = document.createElement('div');
     row.className = 'rubric-row';
     const label = document.createElement('label');
-    label.textContent = d.dimension;
+    label.textContent = dim.dimension;
     const select = document.createElement('select');
-    d.levels.forEach((l) => {
+    dim.levels.forEach((lvl) => {
       const opt = document.createElement('option');
-      opt.value = l;
-      opt.textContent = l;
-      if (state[d.dimension] === l) opt.selected = true;
+      opt.value = lvl;
+      opt.textContent = lvl;
+      if (state[dim.dimension] === lvl) opt.selected = true;
       select.appendChild(opt);
     });
     select.addEventListener('change', () => {
-      state[d.dimension] = select.value;
-      setDay(weekId, day, { rubric: state });
+      state[dim.dimension] = select.value;
+      setState(state);
     });
     row.append(label, select);
     div.appendChild(row);

--- a/styles/components.css
+++ b/styles/components.css
@@ -1,22 +1,29 @@
 /* Components */
 .card{background:var(--card);padding:var(--space-4);border-radius:var(--radius-lg);box-shadow:0 2px 6px var(--shadow);}
 .accordion{border-bottom:1px solid var(--shadow);}
-.accordion button{background:none;color:inherit;width:100%;text-align:left;padding:var(--space-3);font-size:1rem;display:flex;justify-content:space-between;align-items:center;}
-.accordion button:focus{outline:2px solid var(--tint);}
-.accordion-content{display:none;padding:var(--space-3);}
-.accordion-content.open{display:block;}
+.accordion .acc-trigger{background:none;color:inherit;width:100%;text-align:left;padding:var(--space-3);font-size:1rem;display:flex;justify-content:space-between;align-items:center;}
+.accordion .acc-trigger:focus-visible{outline:2px solid var(--tint);}
+.acc-panel{padding:var(--space-3);}
+.acc-panel[hidden]{display:none;}
+.acc-trigger .badges{font-size:0.8rem;color:var(--muted);margin-left:var(--space-2);}
 .progress-ring{width:48px;height:48px;}
 .toast{position:fixed;bottom:var(--space-4);left:50%;transform:translateX(-50%);background:var(--ink);color:var(--card);padding:var(--space-2) var(--space-3);border-radius:var(--radius-sm);}
 .copy{margin-left:var(--space-2);}
 .tabs{display:flex;border-bottom:1px solid var(--shadow);} .tabs button{flex:1;background:none;color:inherit;padding:var(--space-2);} .tabs button[aria-selected="true"]{border-bottom:2px solid var(--tint);}
 .modal{position:fixed;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.4);} .modal.open{display:flex;} .modal-content{background:var(--card);padding:var(--space-4);border-radius:var(--radius-lg);max-width:90%;}
 .checklist li{display:flex;align-items:center;margin-bottom:var(--space-2);} .checklist input{margin-right:var(--space-2);} 
-.timer-display{font-size:2rem;text-align:center;margin-bottom:var(--space-2);} 
+.timer-display{font-size:2rem;text-align:center;margin-bottom:var(--space-2);}
+.timer-controls{display:flex;gap:var(--space-2);justify-content:center;}
 .quiz-question{margin-bottom:var(--space-3);}
-.flashcard{border:1px solid var(--shadow);padding:var(--space-4);text-align:center;border-radius:var(--radius-lg);cursor:pointer;}
+.flashcards{display:flex;flex-direction:column;align-items:center;gap:var(--space-2);}
+.flash-card{border:1px solid var(--shadow);padding:var(--space-4);text-align:center;border-radius:var(--radius-lg);min-width:200px;}
+.flash-controls{display:flex;gap:var(--space-2);}
+.flash-header{align-self:flex-end;font-size:0.8rem;color:var(--muted);}
 .rubric-row{display:flex;align-items:center;margin-bottom:var(--space-2);} .rubric-row label{flex:1;} .rubric-row select{margin-left:var(--space-2);}
 .topbar{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3);}
 .glance{display:flex;align-items:center;gap:var(--space-3);margin:var(--space-3) 0;}
+.word-count{font-size:0.8rem;color:var(--muted);margin-top:var(--space-2);}
+.saved{font-size:0.8rem;color:var(--tint);margin-left:var(--space-2);}
 .day-footer{display:flex;gap:var(--space-2);margin-top:var(--space-4);}
 .day-footer button.success{background:var(--tint);color:var(--card);}
 

--- a/weeks/week.js
+++ b/weeks/week.js
@@ -1,32 +1,63 @@
-import {Accordion, Checklist, Timer, Quiz, Flashcards, Rubric, CopyButton, ProgressRing} from '../scripts/ui/components.js';
-import {getProgress, getDay, setDay} from '../scripts/ui/storage.js';
+import {
+  Accordion,
+  Checklist,
+  Timer,
+  Quiz,
+  Flashcards,
+  Rubric,
+  CopyButton,
+  ProgressRing,
+  Toast,
+} from '../scripts/ui/components.js';
+import { getDay, setDay, getProgress } from '../scripts/ui/storage.js';
 
 const weekId = location.pathname.match(/week(\d+)/)[1];
+let weekData;
+let ring;
 
 async function init() {
-  const res = await fetch(`../data/week${weekId}.json`);
-  const week = await res.json();
-  document.getElementById('week-title').textContent = week.title;
-  document.title = week.title;
+  try {
+    const res = await fetch(`../data/week${weekId}.json`);
+    weekData = await res.json();
+    document.getElementById('week-title').textContent = weekData.title;
+    document.title = weekData.title;
 
-  renderGoals(week.goals);
-  renderDays(week);
-  updateGlance();
+    renderGoals(weekData.goals);
+    renderDays(weekData.days);
+    setupTopbar();
+    updateGlance();
 
-  const hash = location.hash.match(/day-(\d+)/);
-  const q = new URLSearchParams(location.search).get('d');
-  if (hash) openDay(hash[1]);
-  else if (q) openDay(q);
+    // deep link
+    const hash = location.hash.match(/day-(\d+)/);
+    const q = new URLSearchParams(location.search).get('d');
+    const target = hash ? hash[1] : q;
+    if (target) openDay(target);
+    window.addEventListener('hashchange', () => {
+      const m = location.hash.match(/day-(\d+)/);
+      if (m) openDay(m[1]);
+    });
+  } catch (e) {
+    Toast('Failed to load week data');
+  }
+}
+
+function setupTopbar() {
+  const toggle = document.getElementById('dark-toggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+    });
+  }
 }
 
 function renderGoals(goals) {
   const card = document.createElement('div');
   card.className = 'card';
   const h = document.createElement('h2');
-  h.textContent = 'Week goals';
+  h.textContent = 'Week Goals';
   card.appendChild(h);
   const ul = document.createElement('ul');
-  goals.forEach(g => {
+  goals.forEach((g) => {
     const li = document.createElement('li');
     li.textContent = g;
     ul.appendChild(li);
@@ -35,83 +66,131 @@ function renderGoals(goals) {
   document.getElementById('goals').appendChild(card);
 }
 
-function renderDays(week) {
+function renderDays(days) {
   const container = document.getElementById('days');
-  week.days.forEach((day, idx) => {
+  days.forEach((dayObj, idx) => {
+    const dayNum = dayObj.day;
     const content = document.createElement('div');
     content.className = 'day';
 
+    // Focus & vocabulary -------------------------------------------------
     const focus = document.createElement('p');
-    focus.textContent = day.focus;
+    focus.textContent = dayObj.focus;
     content.appendChild(focus);
 
-    // vocabulary
-    if (day.vocabulary) {
+    if (dayObj.vocabulary) {
       const wrap = document.createElement('div');
-      const ul = document.createElement('ul');
-      day.vocabulary.forEach(v => {
+      wrap.className = 'card';
+      const h = document.createElement('h3');
+      h.textContent = 'Vocabulary';
+      wrap.appendChild(h);
+      const list = document.createElement('ul');
+      dayObj.vocabulary.forEach((v) => {
         const li = document.createElement('li');
         li.textContent = v;
-        ul.appendChild(li);
+        list.appendChild(li);
       });
-      wrap.appendChild(ul);
+      wrap.appendChild(list);
 
-      const copy = CopyButton(day.vocabulary.join(', '));
-      wrap.appendChild(copy);
+      const copyAll = CopyButton(dayObj.vocabulary.join(', '));
+      wrap.appendChild(copyAll);
 
-      if (day.usageExamples) {
+      if (dayObj.usageExamples) {
         const toggle = document.createElement('button');
         toggle.textContent = 'Show usage examples';
-        const exWrap = document.createElement('ul');
-        exWrap.hidden = true;
-        day.usageExamples.forEach(ex => {
+        const exList = document.createElement('ul');
+        exList.hidden = true;
+        dayObj.usageExamples.forEach((ex) => {
           const li = document.createElement('li');
           li.textContent = ex;
           li.appendChild(CopyButton(ex));
-          exWrap.appendChild(li);
+          exList.appendChild(li);
         });
         toggle.addEventListener('click', () => {
-          const vis = exWrap.hidden;
-          exWrap.hidden = !vis;
+          const vis = exList.hidden;
+          exList.hidden = !vis;
           toggle.textContent = vis ? 'Hide usage examples' : 'Show usage examples';
         });
         wrap.appendChild(toggle);
-        wrap.appendChild(exWrap);
+        wrap.appendChild(exList);
       }
+
       content.appendChild(wrap);
     }
 
-    // activities
-    day.activities && day.activities.forEach(a => {
-      const card = document.createElement('div');
-      card.className = 'card activity';
-      const h = document.createElement('h3');
-      h.textContent = a.title;
-      card.appendChild(h);
-      if (a.instructions) {
-        const p = document.createElement('p');
-        p.textContent = a.instructions;
-        card.appendChild(p);
-      }
-      if (a.type === 'checklist') {
-        card.appendChild(Checklist({ items: a.items, weekId, day: day.day, key: 'checklist' }));
-      }
-      if (a.type === 'timer') {
-        const match = a.instructions && a.instructions.match(/(\d+)[-\s]?minute/);
-        const secs = match ? parseInt(match[1], 10) * 60 : 300;
-        card.appendChild(Timer({ seconds: secs, weekId, day: day.day }));
-      }
-      content.appendChild(card);
-    });
+    // Activities --------------------------------------------------------
+    dayObj.activities &&
+      dayObj.activities.forEach((act) => {
+        const card = document.createElement('div');
+        card.className = 'card activity';
+        const h = document.createElement('h3');
+        h.textContent = act.title;
+        card.appendChild(h);
+        if (act.instructions) {
+          const p = document.createElement('p');
+          p.textContent = act.instructions;
+          card.appendChild(p);
+        }
 
-    // templates
-    if (day.templates) {
+        if (act.type === 'checklist') {
+          const chk = Checklist({
+            items: act.items,
+            getState: () => getDay(weekId, dayNum).checklist || {},
+            setState: (s) => {
+              setDay(weekId, dayNum, { checklist: s });
+              updateCompletion(dayNum);
+            },
+          });
+          chk.addEventListener('change', () => updateGlance());
+          card.appendChild(chk);
+        }
+
+        if (act.type === 'speak' || act.type === 'timer') {
+          const secs = (act.duration || 1) * 60;
+          const timer = Timer({
+            seconds: secs,
+            storageKey: `w${weekId}d${dayNum}.${act.title}`,
+          });
+          card.appendChild(timer);
+        }
+
+        if (act.type === 'write' || act.type === 'reflect') {
+          const key = act.type === 'write' ? 'notes' : 'reflection';
+          const ta = document.createElement('textarea');
+          ta.value = getDay(weekId, dayNum)[key] || '';
+          const counter = document.createElement('div');
+          counter.className = 'word-count';
+          counter.textContent = `${ta.value.split(/\s+/).filter(Boolean).length} words`;
+          const saveTick = document.createElement('span');
+          saveTick.className = 'saved';
+          saveTick.hidden = true;
+          let db;
+          ta.addEventListener('input', () => {
+            counter.textContent = `${ta.value.split(/\s+/).filter(Boolean).length} words`;
+            clearTimeout(db);
+            db = setTimeout(() => {
+              setDay(weekId, dayNum, { [key]: ta.value });
+              saveTick.hidden = false;
+              setTimeout(() => (saveTick.hidden = true), 1000);
+              updateCompletion(dayNum);
+            }, 500);
+          });
+          card.append(ta, counter, saveTick);
+        }
+
+        content.appendChild(card);
+      });
+
+    // Templates --------------------------------------------------------
+    if (dayObj.templates) {
       const div = document.createElement('div');
       div.className = 'card';
       const h = document.createElement('h3');
       h.textContent = 'Templates';
       div.appendChild(h);
-      day.templates.forEach(t => {
+      const copyAll = CopyButton(dayObj.templates.join('\n'));
+      div.appendChild(copyAll);
+      dayObj.templates.forEach((t) => {
         const p = document.createElement('p');
         p.textContent = t;
         p.appendChild(CopyButton(t));
@@ -120,30 +199,70 @@ function renderDays(week) {
       content.appendChild(div);
     }
 
-    // quiz
-    if (day.quiz) {
-      content.appendChild(Quiz({ questions: day.quiz.questions, weekId, day: day.day }));
+    // Quiz -------------------------------------------------------------
+    if (dayObj.quiz) {
+      const quiz = Quiz({
+        questions: dayObj.quiz.questions,
+        storageGet: () => getDay(weekId, dayNum).quiz,
+        storageSet: (s) => {
+          setDay(weekId, dayNum, { quiz: s });
+          updateDayBadge(dayNum);
+          updateGlance();
+          updateCompletion(dayNum);
+        },
+      });
+      quiz.addEventListener('change', () => {
+        updateDayBadge(dayNum);
+        updateGlance();
+        updateCompletion(dayNum);
+      });
+      content.appendChild(quiz);
     }
 
-    // flashcards
-    if (day.flashcards) {
-      content.appendChild(Flashcards({ cards: day.flashcards, weekId, day: day.day }));
+    // Flashcards -------------------------------------------------------
+    if (dayObj.flashcards) {
+      const fc = Flashcards({
+        cards: dayObj.flashcards,
+        storageGet: () => getDay(weekId, dayNum).flash || {},
+        storageSet: (s) => {
+          setDay(weekId, dayNum, { flash: s });
+          updateDayBadge(dayNum);
+          updateGlance();
+        },
+      });
+      fc.addEventListener('change', () => {
+        updateDayBadge(dayNum);
+        updateGlance();
+      });
+      content.appendChild(fc);
     }
 
-    // homework
-    if (day.homework) {
-      const hw = Checklist({ items: day.homework, weekId, day: day.day, key: 'homework' });
-      const wrapper = document.createElement('div');
-      wrapper.className = 'card';
+    // Homework ---------------------------------------------------------
+    if (dayObj.homework) {
+      const hw = Checklist({
+        items: dayObj.homework,
+        getState: () => getDay(weekId, dayNum).homework || {},
+        setState: (s) => {
+          setDay(weekId, dayNum, { homework: s });
+          updateCompletion(dayNum);
+        },
+      });
+      hw.addEventListener('change', () => updateGlance());
+      const wrap = document.createElement('div');
+      wrap.className = 'card';
       const h = document.createElement('h3');
       h.textContent = 'Homework';
-      wrapper.append(h, hw);
-      content.appendChild(wrapper);
+      wrap.append(h, hw);
+      content.appendChild(wrap);
     }
 
-    // rubric
-    if (day.rubric) {
-      const r = Rubric({ dimensions: day.rubric, weekId, day: day.day });
+    // Rubric ----------------------------------------------------------
+    if (dayObj.rubric) {
+      const r = Rubric({
+        dimensions: dayObj.rubric,
+        getState: () => getDay(weekId, dayNum).rubric || {},
+        setState: (s) => setDay(weekId, dayNum, { rubric: s }),
+      });
       const wrap = document.createElement('div');
       wrap.className = 'card';
       const h = document.createElement('h3');
@@ -152,66 +271,127 @@ function renderDays(week) {
       content.appendChild(wrap);
     }
 
-    // footer nav
+    // Footer -----------------------------------------------------------
     const footer = document.createElement('div');
     footer.className = 'day-footer';
-    const prevBtn = document.createElement('button');
-    prevBtn.textContent = 'Prev Day';
-    prevBtn.disabled = idx === 0;
-    prevBtn.addEventListener('click', () => openDay(day.day - 1));
-    const nextBtn = document.createElement('button');
-    nextBtn.textContent = 'Next Day';
-    nextBtn.disabled = idx === week.days.length - 1;
-    nextBtn.addEventListener('click', () => openDay(day.day + 1));
-    const doneBtn = document.createElement('button');
-    doneBtn.textContent = 'Mark Day Complete';
-    const dayData = getDay(weekId, day.day);
-    if (dayData.done) doneBtn.classList.add('success');
-    doneBtn.addEventListener('click', () => {
-      const d = getDay(weekId, day.day);
+    const prev = document.createElement('button');
+    prev.textContent = 'Prev day';
+    prev.disabled = idx === 0;
+    prev.addEventListener('click', () => openDay(dayNum - 1));
+    const next = document.createElement('button');
+    next.textContent = 'Next day';
+    next.disabled = idx === days.length - 1;
+    next.addEventListener('click', () => openDay(dayNum + 1));
+    const done = document.createElement('button');
+    done.textContent = 'Mark Day Complete';
+    done.addEventListener('click', () => {
+      const d = getDay(weekId, dayNum);
       d.done = !d.done;
-      setDay(weekId, day.day, d);
-      doneBtn.classList.toggle('success', d.done);
+      setDay(weekId, dayNum, d);
+      updateDayBadge(dayNum);
       updateGlance();
+      updateCompletion(dayNum);
     });
-    footer.append(prevBtn, nextBtn, doneBtn);
+    footer.append(done, prev, next);
     content.appendChild(footer);
 
-    const acc = Accordion({ id: `day-${day.day}`, title: `Day ${day.day}: ${day.title}` }, content);
+    const acc = Accordion(
+      { id: `day-${dayNum}`, title: `Day ${dayNum}: ${dayObj.title}` },
+      content,
+    );
+    acc.addEventListener('accordion:open', (e) => {
+      // close siblings
+      document.querySelectorAll('.accordion .acc-trigger').forEach((btn) => {
+        if (btn !== e.target) {
+          btn.setAttribute('aria-expanded', 'false');
+          document.getElementById(btn.getAttribute('aria-controls')).hidden = true;
+        }
+      });
+      location.hash = `day-${dayNum}`;
+    });
     container.appendChild(acc);
+
+    updateDayBadge(dayNum);
+    updateCompletion(dayNum);
   });
+}
+
+function updateDayBadge(day) {
+  const btn = document.querySelector(`#day-${day} .acc-trigger`);
+  if (!btn) return;
+  const badge = btn.querySelector('.badges');
+  const data = getDay(weekId, day);
+  badge.textContent = '';
+  if (data.done) badge.textContent += '✅ ';
+  if (data.quiz && data.quiz.best)
+    badge.textContent += `★ ${data.quiz.best}/${data.quiz.total} `;
+  if (data.flash) {
+    const count = Object.values(data.flash).filter((v) => v === 'mastered').length;
+    if (count) badge.textContent += `🔤 ${count}`;
+  }
 }
 
 function updateGlance() {
   const progress = getProgress(weekId);
   const days = Object.values(progress.days || {});
-  const completed = days.filter(d => d.done).length;
+  const completed = days.filter((d) => d.done).length;
   let vocab = 0;
   let quizzes = 0;
-  days.forEach(d => {
-    if (d.flash) {
-      Object.values(d.flash).forEach(v => { if (v === 'mastered') vocab++; });
-    }
-    if (d.quiz && d.quiz.correct === d.quiz.total) quizzes++;
+  days.forEach((d) => {
+    if (d.flash) Object.values(d.flash).forEach((v) => v === 'mastered' && vocab++);
+    if (d.quiz && d.quiz.best && d.quiz.best / d.quiz.total >= 0.8) quizzes++;
   });
   const wrap = document.getElementById('glance');
   wrap.innerHTML = '';
-  const p = document.createElement('p');
-  p.textContent = `Days ${completed} · Vocab mastered ${vocab} · Quizzes passed ${quizzes}`;
-  wrap.appendChild(p);
-  wrap.appendChild(ProgressRing((completed / 7) * 100));
+  const text = document.createElement('p');
+  text.textContent = `Days done ${completed}/7 · Vocab mastered ${vocab} · Quizzes passed ${quizzes}/7`;
+  ring = ring || ProgressRing((completed / 7) * 100);
+  ring.update((completed / 7) * 100);
+  wrap.append(text, ring);
 }
 
-export function openDay(n) {
-  const btn = document.querySelector(`#day-${n} > h2 > button`);
-  if (btn) {
-    btn.click();
+function openDay(n) {
+  const trigger = document.querySelector(`#day-${n} .acc-trigger`);
+  if (trigger) {
+    trigger.click();
     document.getElementById(`day-${n}`).scrollIntoView();
   }
 }
 
+function updateCompletion(day) {
+  const btn = document.querySelector(`#day-${day} .day-footer button`);
+  if (!btn) return;
+  let ok = true;
+  const data = getDay(weekId, day);
+  switch (day) {
+    case 1:
+      ok = data.quiz && data.homework && Object.values(data.homework).some(Boolean);
+      break;
+    case 2:
+      ok = data.quiz && data.checklist && Object.values(data.checklist).some(Boolean);
+      break;
+    case 3:
+      ok = data.quiz && data.quiz.best && data.quiz.best / data.quiz.total >= 0.8;
+      break;
+    case 4:
+      ok = Boolean(data.quiz);
+      break;
+    case 5:
+      const used = data.flash ? Object.values(data.flash).filter((v) => v === 'mastered').length : 0;
+      ok = data.quiz && used >= 5;
+      break;
+    case 6:
+      ok = Boolean(data.quiz);
+      break;
+    case 7:
+      ok = data.quiz && data.checklist && Object.values(data.checklist).every(Boolean);
+      break;
+  }
+  btn.disabled = !ok;
+}
+
 init();
 
-// expose helper
+// expose for debugging
 window.openDay = openDay;
 

--- a/weeks/week1.html
+++ b/weeks/week1.html
@@ -11,8 +11,9 @@
 </head>
 <body>
 <header class="topbar">
-  <a href="../index.html" class="back">← Back</a>
+  <a href="../index.html" class="back">← Back to Main</a>
   <h1 id="week-title" class="muted"></h1>
+  <button id="dark-toggle" class="no-print">🌓</button>
 </header>
 <main class="stack">
   <section id="goals" class="stack"></section>


### PR DESCRIPTION
## Summary
- add accessible accordion, quiz, flashcard, checklist, timer, rubric and other UI components with persistence
- render week pages with badges, deep links, dark mode toggle and at-a-glance progress
- style accordion, flashcards, timers and add dark-mode toggle to week1

## Testing
- `npm test` *(fails: enoent package.json)*
- `node --check scripts/ui/components.js`
- `node --check weeks/week.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae6d3e93ac832b8ce6fb4925bed8f2