### PR TITLE
Add navigation diagnostics harness

### DIFF
--- a/REPORTS/navigation_audit.md
+++ b/REPORTS/navigation_audit.md
@@ -1,0 +1,31 @@
+# Navigation Audit Report
+
+- Timestamp: Wed Aug 27 02:51:12 UTC 2025
+- Commit: 45ba2e3530f382b93d2275f4fca463bc3d626670
+
+## Results Summary
+
+| Page | Test | Status | Notes |
+|------|------|--------|-------|
+| /index.html | Week cards link to week pages | NOT RUN | Automation failed in headless environment |
+| /index.html | Search deep link | NOT RUN | |
+| /weeks/week1.html | Back link to index | NOT RUN | |
+| /weeks/week1.html | Day accordions toggle and update hash | NOT RUN | |
+| /weeks/week1.html | Prev/Next day buttons | NOT RUN | |
+| /weeks/week1.html | Keyboard toggles | NOT RUN | |
+| /weeks/week1.html | ARIA wiring | NOT RUN | |
+| /weeks/week1.html | Checklist persistence | NOT RUN | |
+| /weeks/week1.html | Timer persistence | NOT RUN | |
+| /weeks/week1.html | Quiz persistence | NOT RUN | |
+| /weeks/week1.html | Flashcards persistence | NOT RUN | |
+| styles/base.css | @media print rules | NOT RUN | |
+
+## Defects & Fixes
+
+Automation did not execute; no defects recorded.
+
+## Next Steps
+
+- Launch a local server (e.g., `python3 -m http.server`) and open `tests/diagnostics.html` in a modern browser.
+- Click **Run tests** to generate a full report.
+- Address any FAIL items and rerun diagnostics.

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,0 +1,40 @@
+export const results = [];
+
+export function record({ page, test, status, message, context }) {
+  results.push({ page, test, status, message, context });
+}
+
+export function assert(condition, message, meta = {}) {
+  record({ ...meta, status: condition ? 'PASS' : 'FAIL', message });
+}
+
+export function renderResults() {
+  const tbody = document.querySelector('#results tbody');
+  tbody.innerHTML = '';
+  results.forEach((r) => {
+    const tr = document.createElement('tr');
+    tr.className = r.status.toLowerCase();
+    tr.innerHTML = `<td>${r.page}</td><td>${r.test}</td><td>${r.status}</td><td>${r.message}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+export function summaryText() {
+  const counts = results.reduce((acc, r) => {
+    acc[r.status] = (acc[r.status] || 0) + 1;
+    return acc;
+  }, {});
+  return `PASS: ${counts.PASS||0}\nFAIL: ${counts.FAIL||0}\nSKIPPED: ${counts.SKIPPED||0}\nINFO: ${counts.INFO||0}`;
+}
+
+export function downloadJSON() {
+  const blob = new Blob([JSON.stringify(results, null, 2)], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'nav_audit.json';
+  a.click();
+}
+
+export async function copySummary() {
+  await navigator.clipboard.writeText(summaryText());
+}

--- a/tests/diagnostics.html
+++ b/tests/diagnostics.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Navigation Diagnostics</title>
+<link rel="stylesheet" href="../styles/tokens.css" />
+<style>
+body{display:flex;font-family:sans-serif;min-height:100vh;margin:0}
+#sidebar{width:200px;border-right:1px solid #ccc;padding:1rem;box-sizing:border-box}
+#main{flex:1;padding:1rem;overflow:auto}
+table{border-collapse:collapse;width:100%}
+th,td{border:1px solid #ccc;padding:0.25rem;font-size:0.8rem}
+.pass{background:#e0ffe0}
+.fail{background:#ffe0e0}
+.info{background:#e0f0ff}
+.skipped{background:#fff8e0}
+</style>
+</head>
+<body>
+<div id="sidebar">
+<button id="run">Run tests</button>
+<button id="rerun">Re-run</button>
+<button id="download-json">Download JSON</button>
+<button id="copy-summary">Copy summary</button>
+</div>
+<div id="main">
+<table id="results"><thead><tr><th>Page</th><th>Test</th><th>Status</th><th>Message</th></tr></thead><tbody></tbody></table>
+<iframe id="frame" style="width:0;height:0;border:0;"></iframe>
+</div>
+<script type="module" src="./diagnostics.js"></script>
+</body>
+</html>

--- a/tests/diagnostics.js
+++ b/tests/diagnostics.js
@@ -1,0 +1,252 @@
+import { assert, record, renderResults, results, downloadJSON, copySummary } from './assertions.js';
+import { waitForSelector, wait, keyPress } from './utils.js';
+
+const iframe = document.getElementById('frame');
+
+function withPage(url, testFn) {
+  return new Promise((resolve) => {
+    iframe.src = url;
+    iframe.onload = async () => {
+      const win = iframe.contentWindow;
+      const doc = win.document;
+      try {
+        await testFn(win, doc);
+      } catch (e) {
+        record({ page: url, test: 'load', status: 'FAIL', message: e.message });
+      }
+      resolve();
+    };
+  });
+}
+
+async function runIndexTests() {
+  await withPage('/', async (win, doc) => {
+    const firstLink = await waitForSelector(doc, '#weeks a');
+    const links = doc.querySelectorAll('#weeks a');
+    assert(links.length === 8, '8 week cards present', { page: '/index.html', test: 'week cards' });
+    for (let i = 1; i <= 8; i++) {
+      const link = Array.from(links).find((a) => a.getAttribute('href') === `weeks/week${i}.html`);
+      assert(Boolean(link), `Week card ${i} links to week${i}.html`, {
+        page: '/index.html',
+        test: `week${i} link`,
+      });
+    }
+    firstLink.click();
+  });
+  assert(
+    iframe.contentWindow.location.pathname.endsWith('/weeks/week1.html'),
+    'Clicking first card navigates to week1',
+    { page: '/index.html', test: 'card navigation' }
+  );
+
+  await withPage('/', async (win, doc) => {
+    const search = doc.getElementById('search');
+    search.value = 'milestone';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    const res = await waitForSelector(doc, '#results a');
+    assert(res.getAttribute('href').includes('week1.html#day-1'), 'Search result links to day', {
+      page: '/index.html',
+      test: 'search link',
+    });
+    res.click();
+  });
+  await wait(300);
+  assert(
+    iframe.contentWindow.location.hash === '#day-1' && iframe.contentWindow.location.pathname.endsWith('/weeks/week1.html'),
+    'Search navigates to deep link',
+    { page: '/index.html', test: 'search navigation' }
+  );
+}
+
+async function runWeekTests(week) {
+  const page = `/weeks/week${week}.html`;
+  await withPage(page, async (win, doc) => {
+    const back = doc.querySelector('a.back');
+    assert(back && back.getAttribute('href') === '../index.html', 'Back link points to index', {
+      page,
+      test: 'back link',
+    });
+    back.click();
+  });
+  assert(
+    iframe.contentWindow.location.pathname.endsWith('/index.html'),
+    'Back link navigates to index',
+    { page: `/weeks/week${week}.html`, test: 'back link nav' }
+  );
+
+  await withPage(page, async (win, doc) => {
+    await waitForSelector(doc, '#week-title');
+    assert(doc.getElementById('week-title').textContent.trim().length > 0, 'Week title rendered', {
+      page,
+      test: 'week title',
+    });
+    assert(Boolean(doc.querySelector('#goals .card')), 'Goals card exists', { page, test: 'goals card' });
+    await waitForSelector(doc, '#glance');
+    assert(Boolean(doc.querySelector('#glance')), 'At-a-glance exists', { page, test: 'glance' });
+    const triggers = doc.querySelectorAll('.acc-trigger');
+    assert(triggers.length === 7, '7 day triggers', { page, test: 'day triggers count' });
+
+    const t1 = doc.getElementById('acc-trigger-day-1');
+    const p1 = doc.getElementById('acc-panel-day-1');
+    t1.click();
+    assert(t1.getAttribute('aria-expanded') === 'true', 'Day1 expands', { page, test: 'day1 expand' });
+    assert(!p1.hidden, 'Day1 panel shown', { page, test: 'day1 panel visible' });
+    assert(win.location.hash === '#day-1', 'Hash updated to day-1', { page, test: 'hash update' });
+    t1.click();
+    assert(t1.getAttribute('aria-expanded') === 'false', 'Day1 collapses', { page, test: 'day1 collapse' });
+
+    // Single-open mode
+    const t2 = doc.getElementById('acc-trigger-day-2');
+    t1.click();
+    t2.click();
+    assert(t1.getAttribute('aria-expanded') === 'false', 'Opening day2 closes day1', { page, test: 'single open' });
+
+    // Prev/Next buttons
+    const t3 = doc.getElementById('acc-trigger-day-3');
+    t3.click();
+    const next3 = doc.querySelector('#day-3 .day-footer button:last-child');
+    next3.click();
+    await wait(100);
+    const t4 = doc.getElementById('acc-trigger-day-4');
+    assert(t4.getAttribute('aria-expanded') === 'true', 'Next opens day4', { page, test: 'next day' });
+    const prev4 = doc.querySelector('#day-4 .day-footer button:nth-child(2)');
+    prev4.click();
+    await wait(100);
+    assert(t2.getAttribute('aria-expanded') === 'true', 'Prev opens day2', { page, test: 'prev day' });
+
+    // Keyboard
+    t2.focus();
+    keyPress(t2, ' ');
+    await wait(50);
+    assert(t2.getAttribute('aria-expanded') === 'false', 'Space toggles day2 close', { page, test: 'keyboard space close' });
+    keyPress(t2, 'Enter');
+    await wait(50);
+    assert(t2.getAttribute('aria-expanded') === 'true', 'Enter toggles day2 open', { page, test: 'keyboard enter open' });
+
+    // ARIA wiring
+    triggers.forEach((btn) => {
+      const ctrl = btn.getAttribute('aria-controls');
+      const panel = doc.getElementById(ctrl);
+      assert(Boolean(panel), 'Panel exists for trigger', { page, test: `aria-controls ${ctrl}` });
+      assert(panel.getAttribute('role') === 'region', 'Panel role region', { page, test: `role region ${ctrl}` });
+      assert(panel.getAttribute('aria-labelledby') === btn.id, 'aria-labelledby links back', {
+        page,
+        test: `aria-labelledby ${ctrl}`,
+      });
+    });
+  });
+
+  await withPage(`${page}#day-1`, async (win, doc) => {
+    const t1 = doc.getElementById('acc-trigger-day-1');
+    assert(t1.getAttribute('aria-expanded') === 'true', 'Hash opens day1', { page: `${page}#day-1`, test: 'deep link hash' });
+  });
+
+  await withPage(`${page}?d=4`, async (win, doc) => {
+    const t4 = doc.getElementById('acc-trigger-day-4');
+    assert(t4.getAttribute('aria-expanded') === 'true', '?d=4 opens day4', { page: `${page}?d=4`, test: 'deep link query' });
+  });
+}
+
+async function runStorageSmoke(week) {
+  const page = `/weeks/week${week}.html`;
+  await withPage(page, async (win, doc) => {
+    const t1 = await waitForSelector(doc, '#acc-trigger-day-1');
+    t1.click();
+    const cb = doc.querySelector('#acc-panel-day-1 input[type="checkbox"]');
+    cb.click();
+    assert(cb.checked, 'Checklist item toggles', { page, test: 'checklist tick' });
+    win.location.reload();
+  });
+  await new Promise((resolve) => (iframe.onload = resolve));
+  await (async () => {
+    const win = iframe.contentWindow;
+    const doc = win.document;
+    const t1 = doc.getElementById('acc-trigger-day-1');
+    t1.click();
+    const cb = doc.querySelector('#acc-panel-day-1 input[type="checkbox"]');
+    assert(cb.checked, 'Checklist persists after reload', { page: page, test: 'checklist persist' });
+
+    const timerStart = doc.querySelector('#acc-panel-day-1 .timer button');
+    const display = doc.querySelector('#acc-panel-day-1 .timer-display');
+    const before = display.textContent;
+    timerStart.click();
+    await wait(1100);
+    timerStart.click();
+    assert(display.textContent !== before, 'Timer counts down', { page, test: 'timer run' });
+    const stored = display.textContent;
+    win.location.reload();
+    await new Promise((resolve) => (iframe.onload = resolve));
+    const win2 = iframe.contentWindow;
+    const doc2 = win2.document;
+    const t1b = doc2.getElementById('acc-trigger-day-1');
+    t1b.click();
+    const display2 = doc2.querySelector('#acc-panel-day-1 .timer-display');
+    assert(display2.textContent === stored, 'Timer persists after reload', { page, test: 'timer persist' });
+
+    const quizRadio = doc2.querySelector('#acc-panel-day-1 form.quiz input[type="radio"]');
+    quizRadio.click();
+    const submit = doc2.querySelector('#acc-panel-day-1 form.quiz button[type="submit"]');
+    submit.click();
+    await wait(100);
+    const res = doc2.querySelector('#acc-panel-day-1 form.quiz p');
+    assert(res.textContent.includes('Score'), 'Quiz result shown', { page, test: 'quiz submit' });
+    win2.location.reload();
+    await new Promise((resolve) => (iframe.onload = resolve));
+    const doc3 = iframe.contentDocument;
+    const t1c = doc3.getElementById('acc-trigger-day-1');
+    t1c.click();
+    const res2 = doc3.querySelector('#acc-panel-day-1 form.quiz p');
+    assert(res2.textContent.includes('Last score'), 'Quiz persists after reload', { page, test: 'quiz persist' });
+
+    const fc = doc3.querySelector('#acc-panel-day-1 .flashcards');
+    const counts = fc.querySelector('.flash-header span');
+    const beforeFc = counts.textContent;
+    const easy = fc.querySelector('.flash-controls button:last-child');
+    easy.click();
+    await wait(50);
+    const afterFc = counts.textContent;
+    assert(beforeFc !== afterFc, 'Flashcard count updates', { page, test: 'flashcard update' });
+    win2.location.reload();
+    await new Promise((resolve) => (iframe.onload = resolve));
+    const doc4 = iframe.contentDocument;
+    const t1d = doc4.getElementById('acc-trigger-day-1');
+    t1d.click();
+    const counts2 = doc4.querySelector('#acc-panel-day-1 .flashcards .flash-header span');
+    assert(counts2.textContent === afterFc, 'Flashcard persists after reload', { page, test: 'flashcard persist' });
+  })();
+}
+
+async function runPrintSanity() {
+  try {
+    const css = await (await fetch('../styles/base.css')).text();
+    assert(/@media\s+print/.test(css), '@media print rules present', {
+      page: 'styles/base.css',
+      test: 'print rules',
+    });
+  } catch (e) {
+    record({ page: 'styles/base.css', test: 'print rules', status: 'INFO', message: 'Could not verify print CSS' });
+  }
+}
+
+export async function runAll() {
+  results.length = 0;
+  await runIndexTests();
+  await runWeekTests(1);
+  await runStorageSmoke(1);
+  await runPrintSanity();
+  for (let i = 2; i <= 8; i++) {
+    record({ page: `/weeks/week${i}.html`, test: 'week suite', status: 'SKIPPED', message: 'Not audited' });
+  }
+  renderResults();
+}
+
+document.getElementById('run').addEventListener('click', runAll);
+document.getElementById('rerun').addEventListener('click', runAll);
+document.getElementById('download-json').addEventListener('click', downloadJSON);
+document.getElementById('copy-summary').addEventListener('click', () => copySummary());
+
+window.runAll = runAll;
+window.runIndexTests = runIndexTests;
+window.runWeekTests = runWeekTests;
+window.runStorageSmoke = runStorageSmoke;
+window.runPrintSanity = runPrintSanity;

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,24 @@
+export function waitForSelector(doc, selector, timeout = 3000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const timer = setInterval(() => {
+      const el = doc.querySelector(selector);
+      if (el) {
+        clearInterval(timer);
+        resolve(el);
+      } else if (Date.now() - start > timeout) {
+        clearInterval(timer);
+        reject(new Error(`Timeout waiting for ${selector}`));
+      }
+    }, 50);
+  });
+}
+
+export function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function keyPress(el, key) {
+  const evt = new KeyboardEvent('keydown', { key, bubbles: true });
+  el.dispatchEvent(evt);
+}


### PR DESCRIPTION
## Summary
- add in-browser diagnostics page for navigation and menu audit
- provide ES-module test utilities and assertion helpers
- include initial navigation audit report template

## Testing
- `node --check tests/utils.js tests/assertions.js tests/diagnostics.js` *(fails: Unexpected token 'export')*
- `node run_diagnostics.mjs` *(fails: headless browser launch / protocol timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6ffd9fe0832b8d7a895c75dd7773