### PR TITLE
feat: adopt Longcheer brand language

### DIFF
--- a/assets/brand/favicon.svg
+++ b/assets/brand/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M16 0a16 16 0 1 0 16 16h-4a12 12 0 1 1-12-12V0z" fill="#D62828"/>
+</svg>

--- a/assets/brand/hero-watermark.svg
+++ b/assets/brand/hero-watermark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <path d="M300 0a300 300 0 1 0 300 300h-60a240 240 0 1 1-240-240V0z" fill="#D62828"/>
+</svg>

--- a/assets/brand/longcheer-logo-horiz.svg
+++ b/assets/brand/longcheer-logo-horiz.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 32">
+  <path d="M16 0a16 16 0 1 0 16 16h-4a12 12 0 1 1-12-12V0z" fill="#D62828"/>
+  <text x="40" y="22" font-family="Arial, sans-serif" font-size="18" fill="#171717">Longcheer</text>
+</svg>

--- a/assets/brand/longcheer-logo-mark.svg
+++ b/assets/brand/longcheer-logo-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <path d="M16 0a16 16 0 1 0 16 16h-4a12 12 0 1 1-12-12V0z" fill="#D62828"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="assets/favicon.svg" />
+<link rel="icon" href="assets/brand/favicon.svg" />
 <link rel="stylesheet" href="styles/tokens.css" />
 <link rel="stylesheet" href="styles/base.css" />
 <link rel="stylesheet" href="styles/components.css" />
@@ -12,20 +12,26 @@
 </head>
 <body>
 <header class="toolbar">
-  <h1>8-week English Program</h1>
+  <img src="assets/brand/longcheer-logo-horiz.svg" alt="Longcheer" class="brand-logo" />
   <input id="search" type="search" placeholder="Search weeks" aria-label="Search weeks" />
-  <button id="dark-toggle" class="btn tinted compact" aria-label="Toggle dark mode">🌓</button>
+  <button id="dark-toggle" class="btn btn--tinted compact" aria-label="Toggle dark mode">🌓</button>
   <div class="actions btn-group">
-    <button id="export" class="btn plain compact">Export</button>
-    <label for="import" class="btn plain compact no-print">Import</label>
+    <button id="export" class="btn btn--plain compact">Export</button>
+    <label for="import" class="btn btn--plain compact no-print">Import</label>
     <input id="import" type="file" hidden class="no-print" />
-    <button id="reset" class="btn plain compact">Reset</button>
-    <button onclick="window.print()" class="btn plain compact">Print</button>
+    <button id="reset" class="btn btn--plain compact">Reset</button>
+    <button onclick="window.print()" class="btn btn--plain compact">Print</button>
   </div>
 </header>
 <main>
-<section id="weeks-container" class="weeks-grid"></section>
-<p id="no-weeks" class="muted" hidden>No weeks found</p>
+  <section class="brand-hero">
+    <div class="brand-lockup">
+      <img src="assets/brand/longcheer-logo-mark.svg" alt="" class="brand-logo" />
+      <h1>龙旗·8周英语学习计划</h1>
+    </div>
+  </section>
+  <section id="weeks-container" class="weeks-grid"></section>
+  <p id="no-weeks" class="muted" hidden>No weeks found</p>
 </main>
 <script type="module" src="scripts/main.js"></script>
 <script type="module">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -50,7 +50,7 @@ async function createWeekCard(week) {
   const ring = ProgressRing(getCompletion(week.id));
   footer.appendChild(ring);
   const open = document.createElement('a');
-  open.className = 'btn filled';
+  open.className = 'btn btn--primary';
   open.href = `weeks/week${week.id}.html`;
   open.textContent = 'Open';
   footer.appendChild(open);

--- a/scripts/ui/components.js
+++ b/scripts/ui/components.js
@@ -17,7 +17,7 @@ export function Toast(msg) {
 // Copy button with toast feedback -------------------------------------
 export function CopyButton(text) {
   const btn = document.createElement('button');
-  btn.className = 'btn tinted compact copy';
+  btn.className = 'btn btn--tinted compact copy';
   btn.textContent = 'Copy';
   btn.addEventListener('click', () => {
     navigator.clipboard.writeText(text).then(() => Toast('Copied'));
@@ -89,7 +89,7 @@ export function ProgressRing(percent = 0) {
 
   const fg = document.createElementNS(svg.namespaceURI, 'path');
   fg.setAttribute('d', 'M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32');
-  fg.setAttribute('stroke', 'var(--tint)');
+  fg.setAttribute('stroke', 'var(--brand-red)');
   fg.setAttribute('stroke-width', '4');
   fg.setAttribute('fill', 'none');
   fg.setAttribute('stroke-linecap', 'round');
@@ -148,10 +148,10 @@ export function Timer({ seconds = 60, storageKey, onComplete, onTick }) {
   const controls = document.createElement('div');
   controls.className = 'timer-controls';
   const start = document.createElement('button');
-  start.className = 'btn tinted compact';
+  start.className = 'btn btn--tinted compact';
   start.textContent = 'Start';
   const reset = document.createElement('button');
-  reset.className = 'btn tinted compact';
+  reset.className = 'btn btn--tinted compact';
   reset.textContent = 'Reset';
   controls.append(start, reset);
   container.append(display, controls);
@@ -224,11 +224,11 @@ export function Quiz({ questions, storageGet, storageSet }) {
 
   const submit = document.createElement('button');
   submit.type = 'submit';
-  submit.className = 'btn filled compact';
+  submit.className = 'btn btn--primary compact';
   submit.textContent = 'Submit';
   const retry = document.createElement('button');
   retry.type = 'button';
-  retry.className = 'btn tinted compact';
+  retry.className = 'btn btn--tinted compact';
   retry.textContent = 'Retry';
   retry.hidden = true;
   const result = document.createElement('p');
@@ -304,19 +304,19 @@ export function Flashcards({ cards, storageGet, storageSet }) {
   card.append(term, def);
 
   const prev = document.createElement('button');
-  prev.className = 'btn tinted compact';
+  prev.className = 'btn btn--tinted compact';
   prev.textContent = 'Prev';
   const next = document.createElement('button');
-  next.className = 'btn tinted compact';
+  next.className = 'btn btn--tinted compact';
   next.textContent = 'Next';
   const flip = document.createElement('button');
-  flip.className = 'btn tinted compact';
+  flip.className = 'btn btn--tinted compact';
   flip.textContent = 'Flip';
   const hard = document.createElement('button');
-  hard.className = 'btn tinted compact';
+  hard.className = 'btn btn--tinted compact';
   hard.textContent = 'Hard';
   const easy = document.createElement('button');
-  easy.className = 'btn tinted compact';
+  easy.className = 'btn btn--tinted compact';
   easy.textContent = 'Easy';
   const controls = document.createElement('div');
   controls.className = 'flash-controls';

--- a/styles/base.css
+++ b/styles/base.css
@@ -11,22 +11,22 @@ body{
   color:var(--label);
   -webkit-font-smoothing:antialiased;
 }
-main,header,footer{max-width:var(--content-max);margin-inline:auto;padding-inline:var(--space-6);} 
+main,header,footer{max-width:var(--content-max);margin-inline:auto;padding-inline:var(--space-6);}
 
 h1,h2,h3,h4,h5,h6{font-weight:var(--fw-semibold);line-height:var(--lh-tight);}
-h1{font-size:var(--fs-h1);font-weight:var(--fw-bold);font-family:"SF Pro Display",var(--font-stack);} 
-h2{font-size:var(--fs-h2);font-family:"SF Pro Display",var(--font-stack);} 
-h3{font-size:var(--fs-h3);} 
-small{font-size:var(--fs-small);} 
+h1{font-size:var(--fs-h1);font-weight:var(--fw-bold);font-family:"SF Pro Display",var(--font-stack);}
+h2{font-size:var(--fs-h2);font-family:"SF Pro Display",var(--font-stack);}
+h3{font-size:var(--fs-h3);}
+small{font-size:var(--fs-small);}
 
-img{max-width:100%;display:block;} 
-a{color:var(--link);text-decoration:none;}a:hover{text-decoration:underline;}
+img{max-width:100%;display:block;}
+a{color:var(--brand-red);text-decoration:none;}a:hover,a:focus{color:var(--brand-red-hover);text-decoration:underline;}
 input,button,select,textarea{font:inherit;color:inherit;}
-::placeholder{color:var(--secondary-label);} 
-:focus-visible{outline:3px solid color-mix(in srgb,var(--tint) 50%,transparent);outline-offset:2px;border-radius:var(--radius-input);} 
+::placeholder{color:var(--secondary);}
+:focus-visible{outline:3px solid color-mix(in srgb,var(--brand-red) 40%,transparent);outline-offset:2px;border-radius:var(--radius-input);}
 
-.stack>*+*{margin-top:var(--space-5);} 
-.grid{display:grid;gap:var(--space-5);} 
-.muted{color:var(--secondary-label);} 
+.stack>*+*{margin-top:var(--space-5);}
+.grid{display:grid;gap:var(--space-5);}
+.muted{color:var(--muted);}
 
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{transition:none!important;animation:none!important;}}

--- a/styles/components.css
+++ b/styles/components.css
@@ -2,37 +2,43 @@
 
 /* Layout helpers */
 .toolbar{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-4);margin-bottom:var(--space-6);} 
-.toolbar input[type="search"]{flex:1;} 
+.toolbar input[type="search"]{flex:1;}
 .toolbar .actions{display:flex;gap:var(--space-3);} 
 
-.card{background:var(--card);border-radius:var(--radius-card);padding:var(--space-6);box-shadow:var(--shadow);} 
+.brand-logo{block-size:32px;inline-size:auto;height:32px;}
+.brand-lockup{display:flex;align-items:center;gap:12px;}
 
-.weeks-grid{display:grid;gap:var(--space-6);grid-template-columns:repeat(auto-fit,minmax(280px,1fr));} 
+.brand-hero{background:var(--brand-red);color:var(--brand-red-ink);position:relative;border-radius:16px;box-shadow:var(--shadow);padding:var(--space-6);}
+.brand-hero::after{content:"";position:absolute;inset:0;background:url("/assets/brand/hero-watermark.svg") no-repeat 0% 100%/600px auto;opacity:.08;pointer-events:none;}
+
+.card{background:var(--card);color:var(--label);border-radius:var(--radius-card);padding:var(--space-6);box-shadow:var(--shadow);} 
+
+.weeks-grid{display:grid;gap:var(--space-6);grid-template-columns:repeat(auto-fit,minmax(280px,1fr));}
 .week-card{display:flex;flex-direction:column;gap:var(--space-4);transition:transform var(--transition),box-shadow var(--transition);} 
-.week-card:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(0,0,0,.12);} 
-.week-card ul{color:var(--secondary-label);list-style:none;padding-left:0;} 
-.week-card .card-footer{display:flex;align-items:center;justify-content:space-between;margin-top:auto;} 
+.week-card:hover{transform:translateY(-2px);box-shadow:var(--shadow);} 
+.week-card ul{color:var(--secondary);list-style:none;padding-left:0;} 
+.week-card .card-footer{display:flex;align-items:center;justify-content:space-between;margin-top:auto;}
 
-.btn{font-weight:var(--fw-semibold);border:none;border-radius:var(--radius-button);cursor:pointer;transition:opacity var(--transition),transform var(--transition),box-shadow var(--transition);padding-inline:var(--space-5);height:44px;display:inline-flex;align-items:center;justify-content:center;gap:var(--space-2);} 
-.btn.compact{height:32px;padding-inline:var(--space-4);} 
+.btn{font-weight:var(--fw-semibold);border:none;border-radius:var(--radius-button);cursor:pointer;transition:background var(--transition),transform var(--transition),box-shadow var(--transition);padding-inline:var(--space-5);height:44px;display:inline-flex;align-items:center;justify-content:center;gap:var(--space-2);} 
+.btn.compact{height:36px;padding-inline:var(--space-4);} 
 .btn:disabled{opacity:.5;cursor:not-allowed;} 
-.btn.filled{background:var(--tint);color:#fff;} 
-.btn.filled:hover{opacity:.9;} 
-.btn.filled:active{transform:scale(.97);} 
-.btn.tinted{background:transparent;color:var(--tint);} 
-.btn.tinted:hover{background:color-mix(in srgb,var(--tint) 20%,transparent);} 
-.btn.tinted:active{background:color-mix(in srgb,var(--tint) 30%,transparent);} 
-.btn.plain{background:transparent;color:var(--label);} 
-.btn.plain:hover{background:var(--fill);} 
-.btn.plain:active{background:var(--fill);opacity:.7;} 
+.btn--primary{background:var(--brand-red);color:var(--brand-red-ink);} 
+.btn--primary:hover{background:var(--brand-red-hover);} 
+.btn--primary:active{transform:scale(.97);} 
+.btn--tinted{background:transparent;color:var(--brand-red);} 
+.btn--tinted:hover{background:var(--fill);} 
+.btn--tinted:active{background:var(--fill);} 
+.btn--plain{background:transparent;color:var(--label);} 
+.btn--plain:hover{background:var(--fill);} 
+.btn--plain:active{background:var(--fill);opacity:.7;} 
 .btn-group{display:flex;gap:var(--space-3);} 
 
-input[type="search"],input[type="text"],input[type="number"],input[type="file"],select,textarea{background:var(--bg-elevated);border:1px solid var(--separator);border-radius:var(--radius-input);padding:0 var(--space-4);height:36px;} 
+input[type="search"],input[type="text"],input[type="number"],input[type="file"],select,textarea{background:var(--bg-alt);border:1px solid var(--separator);border-radius:var(--radius-input);padding:0 var(--space-4);height:36px;} 
 
 .accordion{border-bottom:1px solid var(--separator);} 
-.acc-trigger{width:100%;background:none;border:none;display:flex;align-items:center;justify-content:space-between;padding:var(--space-4);font-size:var(--fs-subhead);font-weight:var(--fw-semibold);transition:background var(--transition);} 
+.acc-trigger{width:100%;background:none;border:none;display:flex;align-items:center;justify-content:space-between;padding:var(--space-4);font-size:var(--fs-subhead);font-weight:var(--fw-semibold);transition:background var(--transition);color:var(--label);} 
 .acc-trigger:hover{background:var(--fill);} 
-.acc-trigger .chevron{transition:transform var(--transition);} 
+.acc-trigger .chevron{transition:transform var(--transition);color:var(--secondary);} 
 .acc-trigger[aria-expanded="true"] .chevron{transform:rotate(180deg);} 
 .acc-panel{padding:var(--space-4);background:var(--card);border-top:1px solid var(--separator);} 
 
@@ -42,7 +48,7 @@ input[type="search"],input[type="text"],input[type="number"],input[type="file"],
 
 .day-footer{display:flex;gap:var(--space-4);margin-top:var(--space-6);justify-content:flex-end;} 
 
-.topbar{display:flex;align-items:center;gap:var(--space-4);padding:var(--space-4) 0;} 
+.topbar{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);padding:var(--space-4) 0;} 
 .topbar .titles{flex:1;} 
 .topbar .titles h1{margin-bottom:var(--space-1);} 
-.topbar .back svg{width:20px;height:20px;}
+.topbar .back svg{width:20px;height:20px;} 

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,4 +1,4 @@
-/* Human Interface Guidelines design tokens */
+/* Longcheer design tokens */
 :root {
   color-scheme: light dark;
 
@@ -28,52 +28,75 @@
 
   /* Radii */
   --radius-card: 12px;
-  --radius-button: 10px;
+  --radius-button: 12px;
   --radius-input: 8px;
 
   /* Motion */
   --transition: 160ms ease-out;
 
-  /* Color roles - light */
-  --bg: #F5F5F7;
-  --bg-elevated: #FFFFFF;
+  /* Brand */
+  --brand-red: #D62828;
+  --brand-red-ink: #FFFFFF;
+  --brand-red-hover: #B71C1C;
+  --brand-red-tint: #E85D5D;
+
+  /* Surfaces */
+  --bg: #FFFFFF;
+  --bg-alt: #F7F7F9;
   --card: #FFFFFF;
-  --separator: rgba(60,60,67,.29);
-  --label: #1C1C1E;
-  --secondary-label: rgba(60,60,67,.6);
-  --tertiary-label: rgba(60,60,67,.3);
-  --link: #0A84FF;
-  --tint: #0A84FF;
+
+  /* Text */
+  --label: #171717;
+  --secondary: #6B7280;
+  --muted: #9CA3AF;
+
+  /* Lines/Fills */
+  --separator: rgba(23,23,23,0.12);
   --fill: #F2F2F7;
-  --shadow: 0 8px 20px rgba(0,0,0,.08);
+
+  /* Shadow */
+  --shadow: 0 8px 20px rgba(0,0,0,0.08);
 }
 
+/* DARK MODE */
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #000000;
-    --bg-elevated: #1C1C1E;
-    --card: #1C1C1E;
-    --separator: rgba(84,84,88,.65);
-    --label: #FFFFFF;
-    --secondary-label: rgba(235,235,245,.6);
-    --tertiary-label: rgba(235,235,245,.3);
-    --link: #0A84FF;
-    --tint: #0A84FF;
+    --brand-red: #D03030;
+    --brand-red-ink: #FFFFFF;
+    --brand-red-hover: #B02525;
+    --brand-red-tint: #EF6A6A;
+
+    --bg: #0B0B0C;
+    --bg-alt: #131316;
+    --card: #18181B;
+
+    --label: #F5F5F5;
+    --secondary: #C7C7CC;
+    --muted: #A1A1AA;
+
+    --separator: rgba(255,255,255,0.16);
     --fill: #2C2C2E;
-    --shadow: 0 8px 20px rgba(0,0,0,.55);
+
+    --shadow: 0 12px 28px rgba(0,0,0,0.55);
   }
 }
 
 body.dark {
-  --bg: #000000;
-  --bg-elevated: #1C1C1E;
-  --card: #1C1C1E;
-  --separator: rgba(84,84,88,.65);
-  --label: #FFFFFF;
-  --secondary-label: rgba(235,235,245,.6);
-  --tertiary-label: rgba(235,235,245,.3);
-  --link: #0A84FF;
-  --tint: #0A84FF;
+  --brand-red: #D03030;
+  --brand-red-ink: #FFFFFF;
+  --brand-red-hover: #B02525;
+  --brand-red-tint: #EF6A6A;
+
+  --bg: #0B0B0C;
+  --bg-alt: #131316;
+  --card: #18181B;
+
+  --label: #F5F5F5;
+  --secondary: #C7C7CC;
+  --muted: #A1A1AA;
+
+  --separator: rgba(255,255,255,0.16);
   --fill: #2C2C2E;
-  --shadow: 0 8px 20px rgba(0,0,0,.55);
+
+  --shadow: 0 12px 28px rgba(0,0,0,0.55);
 }

--- a/tests/diagnostics.html
+++ b/tests/diagnostics.html
@@ -4,6 +4,8 @@
 <meta charset="utf-8" />
 <title>Navigation Diagnostics</title>
 <link rel="stylesheet" href="../styles/tokens.css" />
+<link rel="stylesheet" href="../styles/base.css" />
+<link rel="stylesheet" href="../styles/components.css" />
 <style>
 body{display:flex;font-family:sans-serif;min-height:100vh;margin:0}
 #sidebar{width:200px;border-right:1px solid #ccc;padding:1rem;box-sizing:border-box}

--- a/tests/diagnostics.js
+++ b/tests/diagnostics.js
@@ -57,6 +57,37 @@ async function runIndexTests() {
     'Search navigates to deep link',
     { page: '/index.html', test: 'search navigation' }
   );
+
+  await withPage('/', async (win, doc) => {
+    const btn = doc.createElement('button');
+    btn.className = 'btn btn--primary';
+    doc.body.appendChild(btn);
+    const swatch = doc.createElement('div');
+    swatch.style.background = 'var(--brand-red)';
+    doc.body.appendChild(swatch);
+    const btnBg = win.getComputedStyle(btn).backgroundColor;
+    const tokenBg = win.getComputedStyle(swatch).backgroundColor;
+    assert(btnBg === tokenBg, 'Primary button matches --brand-red', {
+      page: '/index.html',
+      test: 'primary button color',
+    });
+    btn.remove();
+    swatch.remove();
+
+    const hero = doc.querySelector('.brand-hero');
+    assert(Boolean(hero), '.brand-hero present', { page: '/index.html', test: 'brand hero presence' });
+    const heroColor = win.getComputedStyle(hero).color;
+    assert(heroColor === 'rgb(255, 255, 255)', '.brand-hero text is white', {
+      page: '/index.html',
+      test: 'brand hero text',
+    });
+
+    const logo = doc.querySelector('header img, header svg');
+    assert(logo && logo.getAttribute('alt') && logo.getAttribute('alt').trim().length > 0, 'Header logo has alt text', {
+      page: '/index.html',
+      test: 'header logo alt',
+    });
+  });
 }
 
 async function runWeekTests(week) {

--- a/weeks/week.js
+++ b/weeks/week.js
@@ -316,17 +316,17 @@ function renderDays(days) {
     const footer = document.createElement('div');
     footer.className = 'day-footer';
     const prev = document.createElement('button');
-    prev.className = 'btn tinted compact';
+    prev.className = 'btn btn--tinted compact';
     prev.textContent = 'Prev day';
     prev.disabled = idx === 0;
     prev.addEventListener('click', () => openDay(dayNum - 1));
     const next = document.createElement('button');
-    next.className = 'btn tinted compact';
+    next.className = 'btn btn--tinted compact';
     next.textContent = 'Next day';
     next.disabled = idx === days.length - 1;
     next.addEventListener('click', () => openDay(dayNum + 1));
     const done = document.createElement('button');
-    done.className = 'btn filled compact';
+    done.className = 'btn btn--primary compact';
     done.textContent = 'Mark Day Complete';
     done.addEventListener('click', () => {
       const d = getDay(weekId, dayNum);

--- a/weeks/week1.html
+++ b/weeks/week1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="../assets/brand/favicon.svg" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />
@@ -11,18 +11,20 @@
 </head>
 <body>
 <header class="topbar">
-  <a href="../index.html" class="btn plain compact back" aria-label="Back">
-    <svg viewBox="0 0 12 20" xmlns="http://www.w3.org/2000/svg">
-      <path d="M8 4 4 10l4 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  </a>
-  <div class="titles">
-    <h1 id="week-title"></h1>
-    <p class="subtitle muted">Week overview</p>
+  <img src="../assets/brand/longcheer-logo-horiz.svg" alt="Longcheer" class="brand-logo" />
+  <div class="topbar-actions btn-group">
+    <button id="dark-toggle" class="btn btn--tinted compact no-print" aria-label="Toggle dark mode">🌓</button>
+    <a href="../index.html" class="btn btn--plain compact back" aria-label="Back">
+      <svg viewBox="0 0 12 20" xmlns="http://www.w3.org/2000/svg">
+        <path d="M8 4 4 10l4 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </a>
   </div>
-  <button id="dark-toggle" class="btn tinted compact no-print" aria-label="Toggle dark mode">🌓</button>
 </header>
 <main class="stack">
+  <section class="brand-hero">
+    <h1 id="week-title"></h1>
+  </section>
   <section id="goals" class="stack"></section>
   <section id="glance" class="glance" aria-label="Week progress"></section>
   <div id="days" class="stack"></div>


### PR DESCRIPTION
## Summary
- add Longcheer design tokens for brand red, surfaces, and dark mode
- refactor components and pages to use brand hero, logo utilities, and button variants
- extend diagnostics with style checks for brand colors and logo usage

## Testing
- `node tests/diagnostics.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae806758f4832bb7cd42587c022d43