### PR TITLE
refactor: migrate to official Longcheer SVG logos

### DIFF
--- a/REPORTS/logo_inventory.json
+++ b/REPORTS/logo_inventory.json
@@ -1,0 +1,816 @@
+[
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 1,
+    "context": [
+      "",
+      "<!-- longcheer-logo-horiz.svg -->",
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 520 140\" role=\"img\" aria-labelledby=\"title desc\">"
+    ],
+    "match": "longcheer",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 3,
+    "context": [
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 520 140\" role=\"img\" aria-labelledby=\"title desc\">",
+      "  <title id=\"title\">Longcheer Logo (Horizontal)</title>",
+      "  <desc id=\"desc\">Red spiral mark with LONGCHEER wordmark in dark gray.</desc>"
+    ],
+    "match": "Longcheer",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 4,
+    "context": [
+      "  <title id=\"title\">Longcheer Logo (Horizontal)</title>",
+      "  <desc id=\"desc\">Red spiral mark with LONGCHEER wordmark in dark gray.</desc>",
+      ""
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 8,
+    "context": [
+      "    :root{",
+      "      --brand-red:#D62828;",
+      "      --brand-gray:#4A4A4A;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 9,
+    "context": [
+      "      --brand-red:#D62828;",
+      "      --brand-gray:#4A4A4A;",
+      "      --white:#FFFFFF;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 12,
+    "context": [
+      "    }",
+      "    .mark-red{fill:var(--brand-red)}",
+      "    .ink{fill:var(--brand-gray)}"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 13,
+    "context": [
+      "    .mark-red{fill:var(--brand-red)}",
+      "    .ink{fill:var(--brand-gray)}",
+      "    .white{fill:var(--white)}"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 17,
+    "context": [
+      "",
+      "  <!-- Spiral Mark (constructed with simple shapes; transparent background) -->",
+      "  <g transform=\"translate(20,20)\">"
+    ],
+    "match": "Mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 20,
+    "context": [
+      "    <!-- base red disc -->",
+      "    <circle cx=\"50\" cy=\"50\" r=\"50\" class=\"mark-red\"/>",
+      "    <!-- inner hole to form a ring -->"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 34,
+    "context": [
+      "    <!-- small inner dot to complete the spiral feel -->",
+      "    <circle cx=\"50\" cy=\"50\" r=\"10\" class=\"mark-red\"/>",
+      "  </g>"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 37,
+    "context": [
+      "",
+      "  <!-- Wordmark (text-based for editability; swap to outlines if you have official vector) -->",
+      "  <g transform=\"translate(130,88)\">"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-horiz.svg",
+    "line": 45,
+    "context": [
+      "          letter-spacing=\"1.5\">",
+      "      LONGCHEER",
+      "    </text>"
+    ],
+    "match": "LONGCHEER",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 1,
+    "context": [
+      "",
+      "<!-- longcheer-logo-mark.svg -->",
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" role=\"img\" aria-labelledby=\"title desc\">"
+    ],
+    "match": "longcheer",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 3,
+    "context": [
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 120 120\" role=\"img\" aria-labelledby=\"title desc\">",
+      "  <title id=\"title\">Longcheer Mark</title>",
+      "  <desc id=\"desc\">Red spiral mark used by Longcheer.</desc>"
+    ],
+    "match": "Longcheer",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 4,
+    "context": [
+      "  <title id=\"title\">Longcheer Mark</title>",
+      "  <desc id=\"desc\">Red spiral mark used by Longcheer.</desc>",
+      ""
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 7,
+    "context": [
+      "  <style>",
+      "    :root{ --brand-red:#D62828; --white:#FFFFFF; }",
+      "    .mark-red{fill:var(--brand-red)}"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 8,
+    "context": [
+      "    :root{ --brand-red:#D62828; --white:#FFFFFF; }",
+      "    .mark-red{fill:var(--brand-red)}",
+      "    .white{fill:var(--white)}"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 13,
+    "context": [
+      "  <g transform=\"translate(10,10)\">",
+      "    <circle cx=\"50\" cy=\"50\" r=\"50\" class=\"mark-red\"/>",
+      "    <circle cx=\"50\" cy=\"50\" r=\"26\" class=\"white\"/>"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "assets/brand/longcheer-logo-mark.svg",
+    "line": 24,
+    "context": [
+      "      Z\" opacity=\".98\"/>",
+      "    <circle cx=\"50\" cy=\"50\" r=\"10\" class=\"mark-red\"/>",
+      "  </g>"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "data/week1.json",
+    "line": 37,
+    "context": [
+      "      \"flashcards\": [",
+      "        {\"term\":\"milestone\",\"definition\":\"A planned event marking progress.\"},",
+      "        {\"term\":\"deliverable\",\"definition\":\"A tangible output due at a specific date.\"},"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "data/week1.json",
+    "line": 202,
+    "context": [
+      "          {\"q\":\"FPY stands for…\",\"choices\":[\"First Pass Yield\",\"Final Product Year\",\"Factory Process Yard\"],\"answer\":0},",
+      "          {\"q\":\"Acceptance criteria are…\",\"choices\":[\"Marketing slogans\",\"Conditions that must be met to approve a build/phase\",\"Supplier discounts\"],\"answer\":1}",
+      "        ]"
+    ],
+    "match": "Mark",
+    "will_replace": false
+  },
+  {
+    "file": "index.html",
+    "line": 7,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"assets/brand/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"styles/tokens.css\" />"
+    ],
+    "match": "brand",
+    "will_replace": true
+  },
+  {
+    "file": "index.html",
+    "line": 15,
+    "context": [
+      "<header class=\"toolbar\">",
+      "  <img src=\"assets/brand/longcheer-logo-horiz.svg\" alt=\"Longcheer\" class=\"brand-logo\" />",
+      "  <input id=\"search\" type=\"search\" placeholder=\"Search weeks\" aria-label=\"Search weeks\" />"
+    ],
+    "match": "brand",
+    "will_replace": true
+  },
+  {
+    "file": "index.html",
+    "line": 27,
+    "context": [
+      "<main>",
+      "  <section class=\"brand-hero\">",
+      "    <div class=\"brand-lockup\">"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "index.html",
+    "line": 28,
+    "context": [
+      "  <section class=\"brand-hero\">",
+      "    <div class=\"brand-lockup\">",
+      "      <img src=\"assets/brand/longcheer-logo-mark.svg\" alt=\"\" class=\"brand-logo\" />"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "index.html",
+    "line": 29,
+    "context": [
+      "    <div class=\"brand-lockup\">",
+      "      <img src=\"assets/brand/longcheer-logo-mark.svg\" alt=\"\" class=\"brand-logo\" />",
+      "      <h1>龙旗·8周英语学习计划</h1>"
+    ],
+    "match": "brand",
+    "will_replace": true
+  },
+  {
+    "file": "scripts/main.js",
+    "line": 107,
+    "context": [
+      "    const re = new RegExp(`(${q})`, 'gi');",
+      "    el.innerHTML = text.replace(re, '<mark>$1</mark>');",
+      "  });"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "scripts/ui/components.js",
+    "line": 92,
+    "context": [
+      "  fg.setAttribute('d', 'M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32');",
+      "  fg.setAttribute('stroke', 'var(--brand-red)');",
+      "  fg.setAttribute('stroke-width', '4');"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/base.css",
+    "line": 23,
+    "context": [
+      "img{max-width:100%;display:block;}",
+      "a{color:var(--brand-red);text-decoration:none;}a:hover,a:focus{color:var(--brand-red-hover);text-decoration:underline;}",
+      "input,button,select,textarea{font:inherit;color:inherit;}"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/base.css",
+    "line": 26,
+    "context": [
+      "::placeholder{color:var(--secondary);}",
+      ":focus-visible{outline:3px solid color-mix(in srgb,var(--brand-red) 40%,transparent);outline-offset:2px;border-radius:var(--radius-input);}",
+      ""
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/components.css",
+    "line": 8,
+    "context": [
+      "",
+      ".brand-logo{block-size:32px;inline-size:auto;height:32px;}",
+      ".brand-lockup{display:flex;align-items:center;gap:12px;}"
+    ],
+    "match": "brand",
+    "will_replace": true
+  },
+  {
+    "file": "styles/components.css",
+    "line": 9,
+    "context": [
+      ".brand-logo{block-size:32px;inline-size:auto;height:32px;}",
+      ".brand-lockup{display:flex;align-items:center;gap:12px;}",
+      ""
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/components.css",
+    "line": 11,
+    "context": [
+      "",
+      ".brand-hero{background:var(--brand-red);color:var(--brand-red-ink);position:relative;border-radius:16px;box-shadow:var(--shadow);padding:var(--space-6);}",
+      ".brand-hero::after{content:\"\";position:absolute;inset:0;background:url(\"/assets/brand/hero-watermark.svg\") no-repeat 0% 100%/600px auto;opacity:.08;pointer-events:none;}"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/components.css",
+    "line": 12,
+    "context": [
+      ".brand-hero{background:var(--brand-red);color:var(--brand-red-ink);position:relative;border-radius:16px;box-shadow:var(--shadow);padding:var(--space-6);}",
+      ".brand-hero::after{content:\"\";position:absolute;inset:0;background:url(\"/assets/brand/hero-watermark.svg\") no-repeat 0% 100%/600px auto;opacity:.08;pointer-events:none;}",
+      ""
+    ],
+    "match": "brand",
+    "will_replace": true
+  },
+  {
+    "file": "styles/components.css",
+    "line": 25,
+    "context": [
+      ".btn:disabled{opacity:.5;cursor:not-allowed;} ",
+      ".btn--primary{background:var(--brand-red);color:var(--brand-red-ink);} ",
+      ".btn--primary:hover{background:var(--brand-red-hover);} "
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/components.css",
+    "line": 26,
+    "context": [
+      ".btn--primary{background:var(--brand-red);color:var(--brand-red-ink);} ",
+      ".btn--primary:hover{background:var(--brand-red-hover);} ",
+      ".btn--primary:active{transform:scale(.97);} "
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/components.css",
+    "line": 28,
+    "context": [
+      ".btn--primary:active{transform:scale(.97);} ",
+      ".btn--tinted{background:transparent;color:var(--brand-red);} ",
+      ".btn--tinted:hover{background:var(--fill);} "
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 1,
+    "context": [
+      "",
+      "/* Longcheer design tokens */",
+      ":root {"
+    ],
+    "match": "Longcheer",
+    "will_replace": true
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 37,
+    "context": [
+      "",
+      "  /* Brand */",
+      "  --brand-red: #D62828;"
+    ],
+    "match": "Brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 38,
+    "context": [
+      "  /* Brand */",
+      "  --brand-red: #D62828;",
+      "  --brand-red-ink: #FFFFFF;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 39,
+    "context": [
+      "  --brand-red: #D62828;",
+      "  --brand-red-ink: #FFFFFF;",
+      "  --brand-red-hover: #B71C1C;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 40,
+    "context": [
+      "  --brand-red-ink: #FFFFFF;",
+      "  --brand-red-hover: #B71C1C;",
+      "  --brand-red-tint: #E85D5D;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 41,
+    "context": [
+      "  --brand-red-hover: #B71C1C;",
+      "  --brand-red-tint: #E85D5D;",
+      ""
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 64,
+    "context": [
+      "  :root {",
+      "    --brand-red: #D03030;",
+      "    --brand-red-ink: #FFFFFF;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 65,
+    "context": [
+      "    --brand-red: #D03030;",
+      "    --brand-red-ink: #FFFFFF;",
+      "    --brand-red-hover: #B02525;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 66,
+    "context": [
+      "    --brand-red-ink: #FFFFFF;",
+      "    --brand-red-hover: #B02525;",
+      "    --brand-red-tint: #EF6A6A;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 67,
+    "context": [
+      "    --brand-red-hover: #B02525;",
+      "    --brand-red-tint: #EF6A6A;",
+      ""
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 85,
+    "context": [
+      "body.dark {",
+      "  --brand-red: #D03030;",
+      "  --brand-red-ink: #FFFFFF;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 86,
+    "context": [
+      "  --brand-red: #D03030;",
+      "  --brand-red-ink: #FFFFFF;",
+      "  --brand-red-hover: #B02525;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 87,
+    "context": [
+      "  --brand-red-ink: #FFFFFF;",
+      "  --brand-red-hover: #B02525;",
+      "  --brand-red-tint: #EF6A6A;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "styles/tokens.css",
+    "line": 88,
+    "context": [
+      "  --brand-red-hover: #B02525;",
+      "  --brand-red-tint: #EF6A6A;",
+      ""
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 66,
+    "context": [
+      "    const swatch = doc.createElement('div');",
+      "    swatch.style.background = 'var(--brand-red)';",
+      "    doc.body.appendChild(swatch);"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 70,
+    "context": [
+      "    const tokenBg = win.getComputedStyle(swatch).backgroundColor;",
+      "    assert(btnBg === tokenBg, 'Primary button matches --brand-red', {",
+      "      page: '/index.html',"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 77,
+    "context": [
+      "",
+      "    const hero = doc.querySelector('.brand-hero');",
+      "    assert(Boolean(hero), '.brand-hero present', { page: '/index.html', test: 'brand hero presence' });"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 78,
+    "context": [
+      "    const hero = doc.querySelector('.brand-hero');",
+      "    assert(Boolean(hero), '.brand-hero present', { page: '/index.html', test: 'brand hero presence' });",
+      "    const heroColor = win.getComputedStyle(hero).color;"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 80,
+    "context": [
+      "    const heroColor = win.getComputedStyle(hero).color;",
+      "    assert(heroColor === 'rgb(255, 255, 255)', '.brand-hero text is white', {",
+      "      page: '/index.html',"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 82,
+    "context": [
+      "      page: '/index.html',",
+      "      test: 'brand hero text',",
+      "    });"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 85,
+    "context": [
+      "",
+      "    const logo = doc.querySelector('header img, header svg');",
+      "    assert(logo && logo.getAttribute('alt') && logo.getAttribute('alt').trim().length > 0, 'Header logo has alt text', {"
+    ],
+    "match": "logo",
+    "will_replace": true
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 86,
+    "context": [
+      "    const logo = doc.querySelector('header img, header svg');",
+      "    assert(logo && logo.getAttribute('alt') && logo.getAttribute('alt').trim().length > 0, 'Header logo has alt text', {",
+      "      page: '/index.html',"
+    ],
+    "match": "logo",
+    "will_replace": true
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 88,
+    "context": [
+      "      page: '/index.html',",
+      "      test: 'header logo alt',",
+      "    });"
+    ],
+    "match": "logo",
+    "will_replace": true
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 275,
+    "context": [
+      "",
+      "function downloadMarkdown() {",
+      "  const lines = ["
+    ],
+    "match": "Mark",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 287,
+    "context": [
+      "  ];",
+      "  const blob = new Blob([lines.join('\\n')], { type: 'text/markdown' });",
+      "  const a = document.createElement('a');"
+    ],
+    "match": "mark",
+    "will_replace": false
+  },
+  {
+    "file": "tests/diagnostics.js",
+    "line": 297,
+    "context": [
+      "document.getElementById('download-json').addEventListener('click', downloadJSON);",
+      "document.getElementById('download-md').addEventListener('click', downloadMarkdown);",
+      "document.getElementById('copy-summary').addEventListener('click', () => copySummary());"
+    ],
+    "match": "Mark",
+    "will_replace": false
+  },
+  {
+    "file": "weeks/week.js",
+    "line": 330,
+    "context": [
+      "    done.className = 'btn btn--primary compact';",
+      "    done.textContent = 'Mark Day Complete';",
+      "    done.addEventListener('click', () => {"
+    ],
+    "match": "Mark",
+    "will_replace": false
+  },
+  {
+    "file": "weeks/week1.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/brand/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "brand",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week1.html",
+    "line": 14,
+    "context": [
+      "<header class=\"topbar\">",
+      "  <img src=\"../assets/brand/longcheer-logo-horiz.svg\" alt=\"Longcheer\" class=\"brand-logo\" />",
+      "  <div class=\"topbar-actions btn-group\">"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "weeks/week1.html",
+    "line": 25,
+    "context": [
+      "<main class=\"stack\">",
+      "  <section class=\"brand-hero\">",
+      "    <h1 id=\"week-title\"></h1>"
+    ],
+    "match": "brand",
+    "will_replace": false
+  },
+  {
+    "file": "weeks/week2.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week3.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week4.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week5.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week6.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week7.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  },
+  {
+    "file": "weeks/week8.html",
+    "line": 6,
+    "context": [
+      "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />",
+      "<link rel=\"icon\" href=\"../assets/favicon.svg\" />",
+      "<link rel=\"stylesheet\" href=\"../styles/tokens.css\" />"
+    ],
+    "match": "favicon",
+    "will_replace": true
+  }
+]

--- a/REPORTS/logo_migration_report.json
+++ b/REPORTS/logo_migration_report.json
@@ -1,0 +1,146 @@
+[
+  {
+    "page": "index.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week1.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week2.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week3.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week4.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week5.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week6.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week7.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week8.html",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "styles/tokens.css",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "styles/base.css",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "styles/components.css",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/main.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/router.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/ui/components.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/ui/export.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/ui/timers.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/ui/quiz.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/ui/storage.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "scripts/ui/flashcards.js",
+    "test": "legacy logo scan",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "index.html",
+    "test": "header logo present",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week1.html",
+    "test": "header logo present",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "index.html",
+    "test": "favicon updated",
+    "status": "PASS",
+    "message": ""
+  },
+  {
+    "page": "weeks/week1.html",
+    "test": "favicon updated",
+    "status": "PASS",
+    "message": ""
+  }
+]

--- a/REPORTS/logo_migration_report.md
+++ b/REPORTS/logo_migration_report.md
@@ -1,0 +1,30 @@
+# Logo Migration Report
+
+- Timestamp: 2025-08-27T08:21:01.425Z
+
+| Page | Test | Status | Message |
+|------|------|--------|---------|
+| index.html | legacy logo scan | PASS |  |
+| weeks/week1.html | legacy logo scan | PASS |  |
+| weeks/week2.html | legacy logo scan | PASS |  |
+| weeks/week3.html | legacy logo scan | PASS |  |
+| weeks/week4.html | legacy logo scan | PASS |  |
+| weeks/week5.html | legacy logo scan | PASS |  |
+| weeks/week6.html | legacy logo scan | PASS |  |
+| weeks/week7.html | legacy logo scan | PASS |  |
+| weeks/week8.html | legacy logo scan | PASS |  |
+| styles/tokens.css | legacy logo scan | PASS |  |
+| styles/base.css | legacy logo scan | PASS |  |
+| styles/components.css | legacy logo scan | PASS |  |
+| scripts/main.js | legacy logo scan | PASS |  |
+| scripts/router.js | legacy logo scan | PASS |  |
+| scripts/ui/components.js | legacy logo scan | PASS |  |
+| scripts/ui/export.js | legacy logo scan | PASS |  |
+| scripts/ui/timers.js | legacy logo scan | PASS |  |
+| scripts/ui/quiz.js | legacy logo scan | PASS |  |
+| scripts/ui/storage.js | legacy logo scan | PASS |  |
+| scripts/ui/flashcards.js | legacy logo scan | PASS |  |
+| index.html | header logo present | PASS |  |
+| weeks/week1.html | header logo present | PASS |  |
+| index.html | favicon updated | PASS |  |
+| weeks/week1.html | favicon updated | PASS |  |

--- a/assets/brand/favicon.svg
+++ b/assets/brand/favicon.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <path d="M16 0a16 16 0 1 0 16 16h-4a12 12 0 1 1-12-12V0z" fill="#D62828"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <image href="/assets/brand/longcheer-logo-mark.svg" width="100%" height="100%"/>
 </svg>

--- a/assets/brand/longcheer-logo-horiz.svg
+++ b/assets/brand/longcheer-logo-horiz.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- longcheer-logo-horiz.svg -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 140" role="img" aria-labelledby="title desc">
   <title id="title">Longcheer Logo (Horizontal)</title>

--- a/assets/brand/longcheer-logo-mark.svg
+++ b/assets/brand/longcheer-logo-mark.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- longcheer-logo-mark.svg -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
   <title id="title">Longcheer Mark</title>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#0071e3"><circle cx="12" cy="12" r="10"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <image href="/assets/brand/longcheer-logo-mark.svg" width="100%" height="100%"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="assets/brand/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="styles/tokens.css" />
 <link rel="stylesheet" href="styles/base.css" />
 <link rel="stylesheet" href="styles/components.css" />
@@ -12,7 +12,7 @@
 </head>
 <body>
 <header class="toolbar">
-  <img src="assets/brand/longcheer-logo-horiz.svg" alt="Longcheer" class="brand-logo" />
+  <img src="/assets/brand/longcheer-logo-horiz.svg" alt="Longcheer" class="brand-logo" />
   <input id="search" type="search" placeholder="Search weeks" aria-label="Search weeks" />
   <button id="dark-toggle" class="btn btn--tinted compact" aria-label="Toggle dark mode">🌓</button>
   <div class="actions btn-group">
@@ -26,7 +26,7 @@
 <main>
   <section class="brand-hero">
     <div class="brand-lockup">
-      <img src="assets/brand/longcheer-logo-mark.svg" alt="" class="brand-logo" />
+      <img src="/assets/brand/longcheer-logo-mark.svg" alt="Longcheer" class="brand-logo" />
       <h1>龙旗·8周英语学习计划</h1>
     </div>
   </section>

--- a/styles/components.css
+++ b/styles/components.css
@@ -5,7 +5,9 @@
 .toolbar input[type="search"]{flex:1;}
 .toolbar .actions{display:flex;gap:var(--space-3);} 
 
+/* Brand logo sizing */
 .brand-logo{block-size:32px;inline-size:auto;height:32px;}
+@media (max-width:600px){.brand-logo{block-size:24px;height:24px;}}
 .brand-lockup{display:flex;align-items:center;gap:12px;}
 
 .brand-hero{background:var(--brand-red);color:var(--brand-red-ink);position:relative;border-radius:16px;box-shadow:var(--shadow);padding:var(--space-6);}

--- a/tests/diagnostics.html
+++ b/tests/diagnostics.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <title>Navigation Diagnostics</title>
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/tests/logo_migration_checks.js
+++ b/tests/logo_migration_checks.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const root = path.join(__dirname, '..');
+const results = [];
+
+function record(obj){ results.push(obj); }
+
+function read(rel){ return fs.readFileSync(path.join(root, rel), 'utf8'); }
+
+function assert(cond, page, test, message){
+  record({page, test, status: cond ? 'PASS':'FAIL', message: cond? '': message});
+}
+
+function assertNoLegacyLogoRefs(){
+  const files = [
+    'index.html',
+    ...Array.from({length:8}, (_,i)=>`weeks/week${i+1}.html`),
+    'styles/tokens.css','styles/base.css','styles/components.css',
+    'scripts/main.js','scripts/router.js',
+    'scripts/ui/components.js','scripts/ui/export.js','scripts/ui/timers.js',
+    'scripts/ui/quiz.js','scripts/ui/storage.js','scripts/ui/flashcards.js'
+  ];
+  const legacy = /(assets\/favicon\.svg|assets\/brand\/favicon\.svg|logo\.(png|jpe?g)|data:image\/svg\+xml|longcheer-logo(?!-horiz\.svg|-mark\.svg))/i;
+  files.forEach(f=>{
+    const text = read(f);
+    const match = text.match(legacy);
+    assert(!match, f, 'legacy logo scan', match?`Found ${match[0]}`:'');
+  });
+}
+
+function assertHeaderLogoPresent(file){
+  const html = read(file);
+  const ok = /<img(?=[^>]*class="[^"]*brand-logo[^"]*")(?=[^>]*src="\/assets\/brand\/longcheer-logo-horiz.svg")(?=[^>]*alt="Longcheer")[^>]*>/i.test(html);
+  assert(ok, file, 'header logo present', 'missing or incorrect');
+}
+
+function assertFaviconUpdated(file){
+  const html = read(file);
+  const ok = /<link[^>]*rel="icon"[^>]*href="\/assets\/brand\/longcheer-logo-mark.svg"/i.test(html);
+  assert(ok, file, 'favicon updated', 'missing or incorrect');
+}
+
+function run(){
+  assertNoLegacyLogoRefs();
+  assertHeaderLogoPresent('index.html');
+  assertHeaderLogoPresent('weeks/week1.html');
+  assertFaviconUpdated('index.html');
+  assertFaviconUpdated('weeks/week1.html');
+  fs.mkdirSync(path.join(root,'REPORTS'),{recursive:true});
+  fs.writeFileSync(path.join(root,'REPORTS','logo_migration_report.json'), JSON.stringify(results, null, 2));
+  const lines = ['# Logo Migration Report','',`- Timestamp: ${new Date().toISOString()}`,'','| Page | Test | Status | Message |','|------|------|--------|---------|'];
+  results.forEach(r=>lines.push(`| ${r.page} | ${r.test} | ${r.status} | ${r.message} |`));
+  fs.writeFileSync(path.join(root,'REPORTS','logo_migration_report.md'), lines.join('\n'));
+}
+
+run();

--- a/weeks/week1.html
+++ b/weeks/week1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/brand/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />
@@ -11,7 +11,7 @@
 </head>
 <body>
 <header class="topbar">
-  <img src="../assets/brand/longcheer-logo-horiz.svg" alt="Longcheer" class="brand-logo" />
+  <img src="/assets/brand/longcheer-logo-horiz.svg" alt="Longcheer" class="brand-logo" />
   <div class="topbar-actions btn-group">
     <button id="dark-toggle" class="btn btn--tinted compact no-print" aria-label="Toggle dark mode">🌓</button>
     <a href="../index.html" class="btn btn--plain compact back" aria-label="Back">

--- a/weeks/week2.html
+++ b/weeks/week2.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/weeks/week3.html
+++ b/weeks/week3.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/weeks/week4.html
+++ b/weeks/week4.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/weeks/week5.html
+++ b/weeks/week5.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/weeks/week6.html
+++ b/weeks/week6.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/weeks/week7.html
+++ b/weeks/week7.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />

--- a/weeks/week8.html
+++ b/weeks/week8.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" href="../assets/favicon.svg" />
+<link rel="icon" href="/assets/brand/longcheer-logo-mark.svg" type="image/svg+xml" />
 <link rel="stylesheet" href="../styles/tokens.css" />
 <link rel="stylesheet" href="../styles/base.css" />
 <link rel="stylesheet" href="../styles/components.css" />


### PR DESCRIPTION
## Summary
- replace legacy favicon and logo paths with `/assets/brand/longcheer-logo-*.svg`
- add `.brand-logo` utility and responsive sizing
- introduce diagnostics to prevent regressions and record migration reports

## Testing
- `node tests/logo_migration_checks.js`


------
https://chatgpt.com/codex/tasks/task_e_68aebea7972c832ba44b2fae73f4c2ae